### PR TITLE
Combine pkginfo dicts

### DIFF
--- a/AdobeShockwavePlayer/AdobeShockwavePlayer.munki.recipe
+++ b/AdobeShockwavePlayer/AdobeShockwavePlayer.munki.recipe
@@ -42,33 +42,33 @@
             </dict>
         </dict>
         <dict>
-            <key>Arguments</key>
+			<key>Arguments</key>
             <dict>
                 <key>pkg_path</key>
                 <string>%pathname%</string>
                 <key>pkginfo</key>
-					<dict>
-               			<key>name</key>
-               			<string>%NAME%</string>
-               			<key>version</key>
-               			<string>%version%</string>
-                        <key>catalogs</key>
-            			<array>
-           					<string>testing</string>
-			            </array>
-            			<key>description</key>
-			            <string>Adobe Shockwave Player Plugin for Web Browsers</string>
-			            <key>display_name</key>
-			            <string>Adobe Shockwave Player</string>
-			            <key>name</key>
-			            <string>%NAME%</string>
-			            <key>unattended_install</key>
-			            <true/>
-			            <key>category</key>
-			            <string>Browser Plugin</string>
-			            <key>developer</key>
-			            <string>Adobe</string>
-					</dict>
+                <dict>
+                    <key>name</key>
+                    <string>%NAME%</string>
+                    <key>version</key>
+                    <string>%version%</string>
+                    <key>catalogs</key>
+                    <array>
+                        <string>testing</string>
+                    </array>
+                    <key>description</key>
+                    <string>Adobe Shockwave Player Plugin for Web Browsers</string>
+                    <key>display_name</key>
+                    <string>Adobe Shockwave Player</string>
+                    <key>name</key>
+                    <string>%NAME%</string>
+                    <key>unattended_install</key>
+                    <true/>
+                    <key>category</key>
+                    <string>Browser Plugin</string>
+                    <key>developer</key>
+                    <string>Adobe</string>
+                </dict>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
             </dict>


### PR DESCRIPTION
Currently the AdobeShockwavePlayer.munki.recipe has to pkginfo dicts.  Autopkg ignores the 1st one since the 2nd is explicitly called later in the recipe.  Because of this details such as description are not passed to munki.  Also, you cannot override settings.

I've combined the 2 pkginfo's and added category and developer keys as well.  Let me know if you'd like me to change anything.
