### PR TITLE
Update AdobeShockwavePlayer.download.recipe

### DIFF
--- a/AdobeShockwavePlayer/AdobeShockwavePlayer.download.recipe
+++ b/AdobeShockwavePlayer/AdobeShockwavePlayer.download.recipe
@@ -5,7 +5,7 @@
     <key>Description</key>
     <string>Downloads latest Adobe Shockwave Player disk image from macromedia.com.</string>
     <key>Identifier</key>
-    <string>com.github.jleggat.AdobeShockwavePlayer.download</string>
+    <string>com.github.jleggat.download.AdobeShockwavePlayer</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>


### PR DESCRIPTION
Change identifier so that Finder does not see file.download as a in-progress download file from Safari. Most other repos follow this standard where its com.github.user.download.APPNAME.