### PR TITLE
Update Fetch.download.recipe

### DIFF
--- a/Fetch/Fetch.download.recipe
+++ b/Fetch/Fetch.download.recipe
@@ -5,7 +5,7 @@
     <key>Description</key>
     <string>Download recipe for Fetch.  Downloads the latest Fetch from Fetch Softworks website.</string>
     <key>Identifier</key>
-    <string>com.github.jleggat.Fetch.download</string>
+    <string>com.github.jleggat.download.Fetch</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>


### PR DESCRIPTION
Change identifier so that Finder does not see file.download as a in-progress download file from Safari. Most other repos follow this standard where its com.github.user.download.APPNAME.