### PR TITLE
Update url argument to URLDownloader

### DIFF
--- a/Git/Git.download.recipe
+++ b/Git/Git.download.recipe
@@ -37,6 +37,8 @@ Optionally specify MAJOR_OS_VERSION as "mavericks" or "snow-leopard" for compata
 			<string>URLDownloader</string>
 			<key>Arguments</key>
 			<dict>
+				<key>url</key>
+				<string>http://sourceforge.net%match%</string>
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
 			</dict>


### PR DESCRIPTION
SF must have changed their links to be just relative, so we need to add in the host to the URL.