### PR TITLE
Fixup for download URL regex

### DIFF
--- a/Wireshark/Wireshark.download.recipe
+++ b/Wireshark/Wireshark.download.recipe
@@ -21,7 +21,7 @@
                 <key>url</key>
                 <string>https://www.wireshark.org/download.html</string>
                 <key>re_pattern</key>
-                <string>/download/osx/Wireshark.*Intel.*64\.dmg</string>
+                <string>href="(?P&lt;match&gt;https?:\/\/[^"]*/?osx/Wireshark[^"]*Intel[^"]*64\.dmg)"</string>
                 <key>re_flags</key>
                 <array>
                     <string>IGNORECASE</string>
@@ -34,7 +34,7 @@
 			<key>Arguments</key>
 			<dict>
                 <key>url</key>
-                <string>https://www.wireshark.org%match%</string>
+                <string>%match%</string>
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
 			</dict>


### PR DESCRIPTION
* Cleaned up download URL regex in `URLTextSearch` processor
* Removed prepended "https://www.wireshark.org" in `url` var in the
`URLDownloader` processor, since full URL present in regex match in
previous processor step.