### PR TITLE
Use maintained source (and get off SF ftw).

### DIFF
--- a/Git/Git.download.recipe
+++ b/Git/Git.download.recipe
@@ -2,51 +2,51 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>Description</key>
-	<string>Downloads Git for OS X dmg from sourceforge.
+    <key>Description</key>
+    <string>Downloads Git for OS X dmg from sourceforge.
 By default downloads version for the newest OS X release.
 Optionally specify MAJOR_OS_VERSION as "mavericks" or "snow-leopard" for compatability with OS X release.</string>
-	<key>Identifier</key>
-	<string>com.github.jleggat.Git.download</string>
-	<key>Input</key>
-	<dict>
-		<key>NAME</key>
-		<string>Git</string>
-        	<key>DOWNLOAD_URL</key>
-        	<string>http://sourceforge.net/projects/git-osx-installer/files/</string>
-        	<key>MAJOR_OS_VERSION</key>
-        	<string></string>
-        	<key>SEARCH_PATTERN</key>
-		<string>href="(?P&lt;url&gt;.*%MAJOR_OS_VERSION%\.dmg.*)"</string>
-	</dict>
-	<key>Process</key>
-	<array>
-	       <dict>
-			<key>Processor</key>
-           		<string>URLTextSearcher</string>
-           		<key>Arguments</key>
-            		<dict>
-                		<key>url</key>
-                		<string>%DOWNLOAD_URL%</string>
-                		<key>re_pattern</key>
-                		<string>%SEARCH_PATTERN%</string>
-            		</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>URLDownloader</string>
-			<key>Arguments</key>
-			<dict>
-				<key>url</key>
-				<string>http://sourceforge.net%match%</string>
-				<key>filename</key>
-				<string>%NAME%.dmg</string>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>EndOfCheckPhase</string>
-		</dict>
-	</array>
+    <key>Identifier</key>
+    <string>com.github.jleggat.Git.download</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>Git</string>
+        <key>DOWNLOAD_URL</key>
+        <string>http://mackyle.github.io/git-osx-installer/</string>
+        <key>MAJOR_OS_VERSION</key>
+        <string></string>
+        <key>SEARCH_PATTERN</key>
+        <string>href="(.*\.dmg)"</string>
+    </dict>
+    <key>Process</key>
+    <array>
+       <dict>
+        <key>Processor</key>
+           <string>URLTextSearcher</string>
+           <key>Arguments</key>
+            <dict>
+                <key>url</key>
+                <string>%DOWNLOAD_URL%</string>
+                <key>re_pattern</key>
+                <string>%SEARCH_PATTERN%</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+            <key>Arguments</key>
+            <dict>
+                <key>url</key>
+                <string>%match%</string>
+                <key>filename</key>
+                <string>%NAME%.dmg</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+    </array>
 </dict>
 </plist>


### PR DESCRIPTION
- Remove regex group name. The downloader was using match even though
  the group was called url.
- Unintentionally clobbered the mixed space and tab indention with just
  4x spaces.