### PR TITLE
Fix Git recipe to get current version.

### DIFF
--- a/Git/Git.download.recipe
+++ b/Git/Git.download.recipe
@@ -17,7 +17,7 @@ Optionally specify MAJOR_OS_VERSION as "mavericks" or "snow-leopard" for compata
         	<key>MAJOR_OS_VERSION</key>
         	<string></string>
         	<key>SEARCH_PATTERN</key>
-		<string>href="(?P&lt;url&gt;.*%MAJOR_OS_VERSION%\.dmg.*)"</string>
+            <string>href="(.*/projects/git-osx-installer/files/git-.*%MAJOR_OS_VERSION%\.dmg.*)"</string>
 	</dict>
 	<key>Process</key>
 	<array>
@@ -38,7 +38,7 @@ Optionally specify MAJOR_OS_VERSION as "mavericks" or "snow-leopard" for compata
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>http://sourceforge.net%match%</string>
+				<string>%match%</string>
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
 			</dict>


### PR DESCRIPTION
Phew-see what you think about this one.

I noticed that it must be up to the maintainer to decide what is "latest", and the latest version available in the files section is definitely not it.

The change to the regex should now find the first download link in the files list, bypassing the "latest" version that was specified before (as a path, rather than a full URL-this means I had to change the string catting in the urldownloader as well). 

Of course, there's no guarantee that the latest version will actually be at the top of the list; I've seen other projects (Nethack maybe?) where it is actually sorted by date added, which makes things more complicated. If need be, it's possible to just grab all of the download links and write a processor to do version comparisons, but for right now this seems to work for me.