### PR TITLE
Code sig ver note for nvALT

### DIFF
--- a/nvAlt/nvALT.download.recipe
+++ b/nvAlt/nvALT.download.recipe
@@ -3,7 +3,8 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the current release version of nvALT.</string>
+    <string>Downloads the current release version of nvALT.
+    Note: Code signature verification is not possible for nvALT as this time.</string>
     <key>Identifier</key>
     <string>com.github.jleggat.nvALT.download</string>
     <key>Input</key>


### PR DESCRIPTION
nvALT is still using version 1 signature, so we can't run code signature verification on the download recipe. This just adds a note into the description.
```
codesign --display -r- --deep -v /Applications/nvALT.app 
Executable=/Applications/nvALT.app/Contents/MacOS/nvALT
Identifier=net.elasticthreads.nv
Format=app bundle with Mach-O universal (i386 x86_64)
CodeDirectory v=20100 size=5110 flags=0x0(none) hashes=247+5 location=embedded
Signature size=8514
Timestamp=Jun 8, 2013, 12:24:14 PM
Info.plist entries=35
TeamIdentifier=not set
Sealed Resources version=1 rules=4 files=244
designated => anchor apple generic and identifier "net.elasticthreads.nv" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "47TRS7H4BH")
```