### PR TITLE
[EasyFind] Add CodeSignatureVerification

### DIFF
--- a/EasyFind/EasyFind.download.recipe
+++ b/EasyFind/EasyFind.download.recipe
@@ -2,47 +2,71 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>Description</key>
-    <string>Downloads latest EasyFind.</string>
-    <key>Identifier</key>
-    <string>com.github.jleggat.EasyFind.download</string>
-    <key>Input</key>
-    <dict>
-        <key>NAME</key>
-        <string>EasyFind</string>
-        <key>DOWNLOAD_URL</key>
-        <string>http://www.devontechnologies.com/download/products.html</string>
-    </dict>
-    <key>MinimumVersion</key>
-    <string>0.2.0</string>
-    <key>Process</key>
-    <array>
-        <dict>
-            <key>Processor</key>
-            <string>URLTextSearcher</string>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string>%DOWNLOAD_URL%</string>
-                <key>re_pattern</key>
-                <string>[^"]+EasyFind\.app\.zip</string>
-            </dict>
-        </dict>
+	<key>Description</key>
+	<string>Downloads latest EasyFind.</string>
+	<key>Identifier</key>
+	<string>com.github.jleggat.EasyFind.download</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>EasyFind</string>
+		<key>DOWNLOAD_URL</key>
+		<string>http://www.devontechnologies.com/download/products.html</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.2.0</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>URLTextSearcher</string>
+			<key>Arguments</key>
+			<dict>
+				<key>url</key>
+				<string>%DOWNLOAD_URL%</string>
+				<key>re_pattern</key>
+				<string>[^"]+EasyFind\.app\.zip</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-                <string>%match%</string>
+				<string>%match%</string>
 				<key>filename</key>
 				<string>%NAME%.zip</string>
 			</dict>
 		</dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
-    </array>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>Unarchiver</string>
+			<key>Arguments</key>
+			<dict>
+				<key>archive_path</key>
+				<string>%pathname%</string>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
+				<key>purge_destination</key>
+				<true/>
+			</dict>
+		</dict>
+		<dict>
+				<key>Processor</key>
+				<string>CodeSignatureVerifier</string>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/EasyFind.app</string>
+				<key>requirement</key>
+				<string>anchor apple generic and identifier "org.grunenberg.EasyFind" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "679S2QUWR8")</string>
+			</dict>
+		</dict>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Added code signature verification for EasyFind. Also converted spaces to tabs (only for consistency) 😆 

```
$ autopkg run EasyFind.download -v
Processing EasyFind.download...
WARNING: EasyFind.download is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (match): https://s3.amazonaws.com/DTWebsiteSupport/download/freeware/easyfind/4.9.3/EasyFind.app.zip
URLDownloader
URLDownloader: Storing new Last-Modified header: Thu, 17 Jul 2014 06:23:43 GMT
URLDownloader: Storing new ETag header: "38c811eb79b5ff3b8b74c0f4c4f16ad5"
URLDownloader: Downloaded /Users/cwhits/Library/AutoPkg/Cache/com.github.jleggat.EasyFind.download/downloads/EasyFind.zip
EndOfCheckPhase
Unarchiver
Unarchiver: Guessed archive format 'zip' from filename EasyFind.zip
Unarchiver: Unarchived /Users/cwhits/Library/AutoPkg/Cache/com.github.jleggat.EasyFind.download/downloads/EasyFind.zip to /Users/cwhits/Library/AutoPkg/Cache/com.github.jleggat.EasyFind.download/EasyFind
CodeSignatureVerifier
CodeSignatureVerifier: Verifying application bundle signature...
CodeSignatureVerifier: /Users/cwhits/Library/AutoPkg/Cache/com.github.jleggat.EasyFind.download/EasyFind/EasyFind.app: valid on disk
CodeSignatureVerifier: /Users/cwhits/Library/AutoPkg/Cache/com.github.jleggat.EasyFind.download/EasyFind/EasyFind.app: satisfies its Designated Requirement
CodeSignatureVerifier: /Users/cwhits/Library/AutoPkg/Cache/com.github.jleggat.EasyFind.download/EasyFind/EasyFind.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
Receipt written to /Users/cwhits/Library/AutoPkg/Cache/com.github.jleggat.EasyFind.download/receipts/EasyFind-receipt-20161115-143258.plist

The following new items were downloaded:
    Download Path
    -------------
    /Users/cwhits/Library/AutoPkg/Cache/com.github.jleggat.EasyFind.download/downloads/EasyFind.zip
```