### PR TITLE
Add dmg_megabytes to PostgresApp.munki.recipe

### DIFF
--- a/PostgresApp/PostgresApp.munki.recipe
+++ b/PostgresApp/PostgresApp.munki.recipe
@@ -62,6 +62,8 @@
 				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
 				<key>dmg_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
+				<key>dmg_megabytes</key>
+				<string>250</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Over the weekend PostgresApp stopped building for us with the error:

```
Error in local.munki.PostgresApp:
    Processor: DmgCreator:
        Error: creation of /srv/autopkg/Cache/local.munki.PostgresApp/PostgresApp.dmg failed:
            hdiutil: create failed - error -5341
```

According to autopkg/autopkg#87 one work around for this is to add the
-megabytes parameter to DmgCreator; this patch does just that - adding
a value of 250 M (this is an estimate based on rounding up the current size
of 189M).
