### PR TITLE
Switch to Sparkle feed and .dmg files for PostgresApp download

### DIFF
--- a/PostgresApp/PostgresApp.download.recipe
+++ b/PostgresApp/PostgresApp.download.recipe
@@ -17,26 +17,22 @@
     <string>0.2.0</string>
     <key>Process</key>
     <array>
-        <dict>
-            <key>Processor</key>
-            <string>URLTextSearcher</string>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string>%APP_URL%</string>
-                <key>re_pattern</key>
-                <string>https://.*/download/.*/Postgres-.*\.zip</string>
-            </dict>
-        </dict>
+      <dict>
+          <key>Processor</key>
+          <string>SparkleUpdateInfoProvider</string>
+          <key>Arguments</key>
+          <dict>
+              <key>appcast_url</key>
+              <string>https://postgresapp.com/sparkle/updates.xml</string>
+          </dict>
+      </dict>
         <dict>
 			<key>Processor</key>
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>
-				<key>url</key>
-                <string>%match%</string>
                 <key>filename</key>
-                <string>%NAME%.zip</string>
+                <string>%NAME%.dmg</string>
             </dict>
         </dict>
         <dict>

--- a/PostgresApp/PostgresApp.install.recipe
+++ b/PostgresApp/PostgresApp.install.recipe
@@ -19,37 +19,13 @@
     <string>com.github.jleggat.PostgresApp.download</string>
     <key>Process</key>
 	<array>
-		<dict>
-			<key>Processor</key>
-			<string>Unarchiver</string>
-			<key>Arguments</key>
-			<dict>
-				<key>archive_path</key>
-				<string>%pathname%</string>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
-				<key>purge_destination</key>
-				<true/>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>DmgCreator</string>
-			<key>Arguments</key>
-			<dict>
-				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
-				<key>dmg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
-			</dict>
-		</dict>
         <dict>
             <key>Processor</key>
             <string>InstallFromDMG</string>
             <key>Arguments</key>
             <dict>
                 <key>dmg_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
+                <string>%pathname%</string>
                 <key>items_to_copy</key>
                 <array>
                     <dict>

--- a/PostgresApp/PostgresApp.munki.recipe
+++ b/PostgresApp/PostgresApp.munki.recipe
@@ -41,34 +41,10 @@
     <key>Process</key>
 	<array>
 		<dict>
-			<key>Processor</key>
-			<string>Unarchiver</string>
-			<key>Arguments</key>
-			<dict>
-				<key>archive_path</key>
-				<string>%pathname%</string>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
-				<key>purge_destination</key>
-				<true/>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>DmgCreator</string>
-			<key>Arguments</key>
-			<dict>
-				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
-				<key>dmg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
-			</dict>
-		</dict>
-		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>pkg_path</key>
-				<string>%dmg_path%</string>
+				<string>%pathname%</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
 			</dict>


### PR DESCRIPTION
Postgres.app is now distributed in disk images instead of zip files. They also now provide a Sparkle feed which may be more reliable than scraping the downloads page. Fixes #51.