### PR TITLE
Fetch download location seems to have changed

### DIFF
--- a/Fetch/Fetch.download.recipe
+++ b/Fetch/Fetch.download.recipe
@@ -30,17 +30,6 @@
                 <string>%SEARCH_PATTERN%</string>
             </dict>
         </dict>
-        <dict>
-            <key>Processor</key>
-            <string>URLTextSearcher</string>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string>%SEARCH_URL%%match%</string>
-                <key>re_pattern</key>
-                <string>%SEARCH_PATTERN%</string>
-            </dict>
-        </dict>
 		<dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
Overnight our build failed:

> The following recipes failed:
>     Fetch.munki.recipe
>        Error in local.munki.Fetch: Processor: URLTextSearcher: Error: No match found on URL: https://www.fetchsoftworks.com/fetch/download/Fetch_5.7.6.dmg?direct=1

Running throught the steps by hand, it seems that the download link on
the front page now redirects and downloads the .dmg:

 $ curl  --dump-header - https://fetchsoftworks.com/fetch/download/Fetch_5.7.6.dmg?direct=1
 HTTP/1.1 301 Moved Permanently
 Date: Fri, 31 Mar 2017 06:17:20 GMT
 Server: Apache/2.4.25
 X-Kitty: Meow!
 X-test: 1
 Location: http://getfetch.com/Fetch_5.7.6.dmg
 Content-Length: 0
 Content-Type: text/html

so this patch removes the now unnecesary URLTextSearcher  processor