### PR TITLE
Fetch download changes

### DIFF
--- a/Fetch/Fetch.download.recipe
+++ b/Fetch/Fetch.download.recipe
@@ -30,13 +30,24 @@
                 <string>%SEARCH_PATTERN%</string>
             </dict>
         </dict>
+        <dict>
+            <key>Processor</key>
+            <string>URLTextSearcher</string>
+            <key>Arguments</key>
+            <dict>
+                <key>url</key>
+                <string>%SEARCH_URL%%match%</string>
+                <key>re_pattern</key>
+                <string>%SEARCH_PATTERN%</string>
+            </dict>
+        </dict>
 		<dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-                <string>%SEARCH_URL%%match%</string>
+                <string>%SEARCH_URL%%match%?direct=1</string>
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
 			</dict>


### PR DESCRIPTION
Overnight the Fetch download seems to have changed to download HTML, rather than the DMG:

 $ file /srv/autopkg/Cache/local.munki.Fetch/downloads/Fetch.d mg
 /srv/autopkg/Cache/local.munki.Fetch/downloads/Fetch.dmg: HTML document text

This is because the page age
  http://fetchsoftworks.com/fetch/download/Fetch_5.7.6.dmg
is now HTML which automagically starts the download in my browser,
providing a direct download link too.

This PR reverses the earlier pull request, which means that the recipe now checks
the intermediate page for the new link.