### PR TITLE
Fetch - Build %version% from URLTextSearcher

### DIFF
--- a/Fetch/Fetch.download.recipe
+++ b/Fetch/Fetch.download.recipe
@@ -11,9 +11,9 @@
         <key>NAME</key>
         <string>Fetch</string>
         <key>SEARCH_URL</key>
-        <string>https://www.fetchsoftworks.com</string>
+        <string>https://fetchsoftworks.com</string>
         <key>SEARCH_PATTERN</key>
-        <string>[^"]+\.dmg[^"]*</string>
+        <string>(?P&lt;url&gt;fetch/download/Fetch_(?P&lt;version&gt;[0-9.]+)\.dmg)</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.0</string>
@@ -32,30 +32,19 @@
         </dict>
         <dict>
             <key>Processor</key>
-            <string>URLTextSearcher</string>
+            <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>%SEARCH_URL%%match%</string>
-                <key>re_pattern</key>
-                <string>%SEARCH_PATTERN%</string>
+                <string>%SEARCH_URL%/%url%?direct=1</string>
+                <key>filename</key>
+                <string>%NAME%-%version%.dmg</string>
             </dict>
         </dict>
-		<dict>
-			<key>Processor</key>
-			<string>URLDownloader</string>
-			<key>Arguments</key>
-			<dict>
-				<key>url</key>
-                <string>%SEARCH_URL%%match%?direct=1</string>
-				<key>filename</key>
-				<string>%NAME%.dmg</string>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>EndOfCheckPhase</string>
-		</dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
     </array>
 </dict>
 </plist>


### PR DESCRIPTION
Build the %version% substitution value from URLTextSearcher.
This allows us to remove two processor steps between the download and pkg recipes.

Also, since Fetch has two different version strings that can't be easily compared (v5.7.7 vs v5.7.1795), this requires an EA to pull a version string to compare in the JSS.
Getting the version string from URLTextSearcher (which matches the jss_inventory_app <-> version) and using it as criteria in a Smart Group Template removes the need for an EA.