### PR TITLE
Fixes issue with Download recipe

### DIFF
--- a/Fetch/Fetch.download.recipe
+++ b/Fetch/Fetch.download.recipe
@@ -36,7 +36,7 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>%SEARCH_URL%/%url%?direct=1</string>
+                <string>%SEARCH_URL%/%match%?direct=1</string>
                 <key>filename</key>
                 <string>%NAME%-%version%.dmg</string>
             </dict>


### PR DESCRIPTION
switching to `%match%` from `%url%` fixes an issue where the returned
URL generates a 404.