### PR TITLE
Change the "Version" String to the Web Release

### DIFF
--- a/Fetch/Fetch.pkg.recipe
+++ b/Fetch/Fetch.pkg.recipe
@@ -32,17 +32,6 @@ Set REGISTRANTNAME to name used to register a Fetch license agreement.</string>
     <array>
         <dict>
             <key>Processor</key>
-            <string>Versioner</string>
-            <key>Arguments</key>
-            <dict>
-                <key>input_plist_path</key>
-                <string>%pathname%/Fetch.app/Contents/Info.plist</string>
-		<key>plist_version_key</key>
-		<string>CFBundleVersion</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
             <string>PkgRootCreator</string>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
This will keep the "Version" variable using the release number pulled from the website.
i.e. `5.7.7` instead of `5.7.1795`