### PR TITLE
Fix uninstall method for Webmin

### DIFF
--- a/Webmin/Webmin.munki.recipe
+++ b/Webmin/Webmin.munki.recipe
@@ -35,8 +35,6 @@
 			<key>uninstallable</key>
 			<true/>
 			<key>uninstall_method</key>
-			<string>uninstall_script</string>
-			<key>uninstall_script</key>
 			<string>/etc/webmin/run-uninstall.sh</string>
         </dict>
     </dict>


### PR DESCRIPTION
According to the Munki wiki, the possible values for `uninstall_method` include one of:

- removepackages
- remove_copied_items
- remove_app
- uninstall_script
- remove_profile
- one of the "Adobe*" removal methods
- **the absolute path to a local script**

https://github.com/munki/munki/wiki/Supported-Pkginfo-Keys

So there's no need to set `uninstall_script` as the method; just use the path to the script itself.