### PR TITLE
Remove NAME variable from app paths

### DIFF
--- a/Fetch/Fetch.pkg.recipe
+++ b/Fetch/Fetch.pkg.recipe
@@ -50,9 +50,9 @@ Set REGISTRANTNAME to name used to register a Fetch license agreement.</string>
             <key>Arguments</key>
             <dict>
                 <key>source_path</key>
-                <string>%pathname%/%NAME%.app</string>
+                <string>%pathname%/Fetch.app</string>
                 <key>destination_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app</string>
+                <string>%pkgroot%/Applications/Fetch.app</string>
             </dict>
         </dict>
         <dict>

--- a/LightPaper/LightPaper.install.recipe
+++ b/LightPaper/LightPaper.install.recipe
@@ -52,7 +52,7 @@
 		<array>
 		    <dict>
 			<key>source_item</key>
-			<string>%NAME%.app</string>
+			<string>LightPaper.app</string>
 			<key>destination_path</key>
 			<string>/Applications/</string>
 		    </dict>

--- a/LightPaper/LightPaper.pkg.recipe
+++ b/LightPaper/LightPaper.pkg.recipe
@@ -40,7 +40,7 @@
 	    <key>Arguments</key>
 	    <dict>
 		<key>input_plist_path</key>
-		<string>%destination_path%/%NAME%.app/Contents/Info.plist</string>
+		<string>%destination_path%/LightPaper.app/Contents/Info.plist</string>
 	    </dict>
 	</dict>
 	<dict>
@@ -63,9 +63,9 @@
 	    <key>Arguments</key>
 	    <dict>
 		<key>source_path</key>
-		<string>%destination_path%/%NAME%.app</string>
+		<string>%destination_path%/LightPaper.app</string>
 		<key>destination_path</key>
-		<string>%pkgroot%/Applications/%NAME%.app</string>
+		<string>%pkgroot%/Applications/LightPaper.app</string>
 	    </dict>
 	</dict>
 	<dict>

--- a/MacDown/MacDown.install.recipe
+++ b/MacDown/MacDown.install.recipe
@@ -52,7 +52,7 @@
 		<array>
 		    <dict>
 			<key>source_item</key>
-			<string>%NAME%.app</string>
+			<string>MacDown.app</string>
 			<key>destination_path</key>
 			<string>/Applications/</string>
 		    </dict>

--- a/MacDown/MacDown.pkg.recipe
+++ b/MacDown/MacDown.pkg.recipe
@@ -38,7 +38,7 @@
 	    <key>Arguments</key>
 	    <dict>
 		<key>input_plist_path</key>
-		<string>%destination_path%/%NAME%.app/Contents/Info.plist</string>
+		<string>%destination_path%/MacDown.app/Contents/Info.plist</string>
 	    </dict>
 	</dict>
 	<dict>
@@ -61,9 +61,9 @@
 	    <key>Arguments</key>
 	    <dict>
 		<key>source_path</key>
-		<string>%destination_path%/%NAME%.app</string>
+		<string>%destination_path%/MacDown.app</string>
 		<key>destination_path</key>
-		<string>%pkgroot%/Applications/%NAME%.app</string>
+		<string>%pkgroot%/Applications/MacDown.app</string>
 	    </dict>
 	</dict>
 	<dict>


### PR DESCRIPTION
Because variables can be overridden, it's a good idea to make sure that the recipe will still work even if a non-default variables used. One issue that would prevent recipes from running is using a `NAME` variable in paths that should be hard-coded (e.g. `/Applications/Foo.app`).

This PR removes the `NAME` variable from all file paths and replaces it with the actual app name, which should make the recipe more resilient for overrides.