### PR TITLE
Basic python3 compatibility

### DIFF
--- a/AdobeShockwavePlayer/AdobeShockwaveVersioner.py
+++ b/AdobeShockwavePlayer/AdobeShockwaveVersioner.py
@@ -55,7 +55,7 @@ class AdobeShockwaveVersioner(Processor):
                 id = node.attrib.get('packageIdentifier')
 
             return v.strip('"|\''), id.strip('.pkg')
-        except BaseException as e:
+        except Exception as e:
             raise ProcessorError('Could not retrieve Version from %s' % file)
 
     def main(self):

--- a/AdobeShockwavePlayer/AdobeShockwaveVersioner.py
+++ b/AdobeShockwavePlayer/AdobeShockwaveVersioner.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 
+from __future__ import absolute_import
 import os.path
 from xml.etree import ElementTree
 

--- a/AdobeShockwavePlayer/AdobeShockwaveVersioner.py
+++ b/AdobeShockwavePlayer/AdobeShockwaveVersioner.py
@@ -16,11 +16,10 @@
 
 
 from __future__ import absolute_import
-import os.path
+
 from xml.etree import ElementTree
 
 from autopkglib import Processor, ProcessorError
-
 
 __all__ = ["AdobeShockwaveVersioner"]
 

--- a/Fetch/FetchScriptsPath.py
+++ b/Fetch/FetchScriptsPath.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import glob
 import os
 from autopkglib import Processor, ProcessorError

--- a/Fetch/FetchScriptsPath.py
+++ b/Fetch/FetchScriptsPath.py
@@ -15,10 +15,10 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-import glob
-import os
-from autopkglib import Processor, ProcessorError
 
+import os
+
+from autopkglib import Processor, ProcessorError
 
 __all__ = ["FetchScriptsPath"]
 
@@ -45,7 +45,7 @@ class FetchScriptsPath(Processor):
         dirpath = os.path.join(basepath, dirname)
         if os.path.isdir(dirpath):
             return os.path.abspath(dirpath)
-        return None 
+        return None
 
 
     def main(self):

--- a/Monit/MonitVersioner.py
+++ b/Monit/MonitVersioner.py
@@ -15,11 +15,12 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-import os.path
-import subprocess
-import re
-from autopkglib import Processor, ProcessorError
 
+import os.path
+import re
+import subprocess
+
+from autopkglib import Processor, ProcessorError
 
 __all__ = ["MonitVersioner"]
 

--- a/Monit/MonitVersioner.py
+++ b/Monit/MonitVersioner.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os.path
 import subprocess
 import re

--- a/TestDisk/TestDiskVersioner.py
+++ b/TestDisk/TestDiskVersioner.py
@@ -15,11 +15,10 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-import os.path
-import subprocess
-import re
-from autopkglib import Processor, ProcessorError
 
+import os.path
+
+from autopkglib import Processor, ProcessorError
 
 __all__ = ["TestDiskVersioner"]
 

--- a/TestDisk/TestDiskVersioner.py
+++ b/TestDisk/TestDiskVersioner.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os.path
 import subprocess
 import re


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later, but this should catch the low-hanging fruit right now.