### PR TITLE
Update Wireshark.munki.recipe

### DIFF
--- a/Wireshark/Wireshark.munki.recipe
+++ b/Wireshark/Wireshark.munki.recipe
@@ -30,10 +30,12 @@
 			<string>Wireshark Foundation</string>
 			<key>postinstall_script</key>
 			<string>#!/bin/bash
-                # Add directory traversal for the entire application and ensure 
-                # all executables are executable by group and other
-                /bin/chmod -R go+rX /Applications/Wireshark.app
-            </string>
+if [ -d "/Applications/Wireshark.app" ]; then
+	# Add directory traversal for the entire application and ensure 
+	# all executables are executable by group and other
+	/bin/chmod -R u=rwX,go=rX /Applications/Wireshark.app
+fi
+			</string>
 			<key>minimum_os_version</key>
 			<string>10.12.0</string>
 		</dict>


### PR DESCRIPTION
Checks if `/Applications/Wireshark.app` is installed then `chmod -R 644` the app

I had been getting a permissions error before where the `Wireshark.app/Contents/Resources/shared/wireshark` directory didn't have read perms on the `Other` group - causing a pop up when starting Wireshark.