### PR TITLE
Update MacVim.download.recipe

### DIFF
--- a/MacVim/MacVim.download.recipe
+++ b/MacVim/MacVim.download.recipe
@@ -2,53 +2,60 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>Description</key>
-    <string>Downloads the latest release version of MacVim for OS X where MAJOR_OS_VERSION is Snow-Leopard, Mountain-Lion or Mavericks (default).</string>
-    <key>Identifier</key>
-    <string>com.github.jleggat.MacVim.download</string>
-    <key>Input</key>
-    <dict>
-        <key>NAME</key>
-        <string>MacVim</string>
-        <key>MAJOR_OS_VERSION</key>
-        <string>Mavericks</string>
-		<key>REPO_OWNER</key>
-		<string>b4winckler</string>
-		<key>REPO_NAME</key>
-		<string>macvim</string>
-        	<key>SEARCH_PATTERN</key>
-        	<string>&lt;a href="(/.*-%MAJOR_OS_VERSION%\.tbz)"</string>
-    </dict>
-    <key>MinimumVersion</key>
-    <string>0.3.0</string>
-    <key>Process</key>
-    <array>
-        <dict>
-            <key>Processor</key>
-            <string>URLTextSearcher</string>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string>https://github.com/%REPO_OWNER%/%REPO_NAME%/releases</string>
-                <key>re_pattern</key>
-                <string>%SEARCH_PATTERN%</string>
-            </dict>
-        </dict>
+	<key>Description</key>
+	<string>Downloads the latest release version of MacVim for OS X where MAJOR_OS_VERSION is Snow-Leopard, Mountain-Lion or Mavericks (default).</string>
+	<key>Identifier</key>
+	<string>com.github.jleggat.MacVim.download</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>MacVim</string>
+		<key>PRERELEASE</key>
+		<string></string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.3.0</string>
+	<key>Process</key>
+	<array>
 		<dict>
-			<key>Processor</key>
-			<string>URLDownloader</string>
 			<key>Arguments</key>
 			<dict>
-				<key>url</key>
-                		<string>https://github.com%match%</string>
+				<key>asset_regex</key>
+				<string>^.*.dmg$</string>
+				<key>github_repo</key>
+				<string>macvim-dev/macvim</string>
+				<key>include_preleases</key>
+				<string>%PRERELEASE%</string>
+			</dict>
+			<key>Processor</key>
+			<string>GitHubReleasesInfoProvider</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
 				<key>filename</key>
-				<string>%NAME%.tbz</string>
+				<string>%NAME%.dmg</string>
+			</dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%pathname%/MacVim.app</string>
+				<key>requirement</key>
+				<string>identifier "org.vim.MacVim" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = WG3S88DD2E</string>
+				<key>strict_verification</key>
+				<true/>
 			</dict>
 		</dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
-    </array>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
- Add CodeSignatureVerifier processor
- Standardize on tabs.  recipe had equal amount tabs vs. spaces, so just chose one.
- Use GitHub available verison to download