### PR TITLE
More MacVim updates

### DIFF
--- a/MacVim/MacVim.munki.recipe
+++ b/MacVim/MacVim.munki.recipe
@@ -4,8 +4,8 @@
 <dict>
     <key>Description</key>
     <string>Downloads the current release version of MacVim where MAJOR_OS_VERSION is Snow-Leopard, Mountain-Lion or Mavericks (default).</string>
-	<key>Identifier</key>
-	<string>com.github.jleggat.MacVim.munki</string>
+    <key>Identifier</key>
+    <string>com.github.jleggat.MacVim.munki</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>
@@ -18,6 +18,8 @@
             <array>
                 <string>testing</string>
             </array>
+            <key>category</key>
+            <string>Text Editors</string>
             <key>description</key>
             <string>MacVim supports multiple windows with tabbed editing and a host of other features such as:
 
@@ -28,29 +30,27 @@
 * ODB editor support,
 
 and more. Most importantly, MacVim brings you the full power of Vim 7.4 to Mac OS X.</string>
+            <key>developer</key>
+            <string>Björn Winckler</string>
             <key>display_name</key>
             <string>Vim - the text editor - for Mac OS X </string>
             <key>name</key>
             <string>%NAME%</string>
             <key>unattended_install</key>
             <true/>
-			<key>category</key>
-			<string>Text Editors</string>
-			<key>developer</key>
-			<string>Björn Winckler</string>
         </dict>
     </dict>
     <key>MinimumVersion</key>
     <string>0.3.0</string>
     <key>ParentRecipe</key>
-    <string>com.github.jleggat.MacVim.pkg</string>
+    <string>com.github.jleggat.MacVim.download</string>
     <key>Process</key>
     <array>
         <dict>
             <key>Arguments</key>
             <dict>
                 <key>pkg_path</key>
-                <string>%pkg_path%</string>
+                <string>%pathname%</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
             </dict>

--- a/MacVim/MacVim.pkg.recipe
+++ b/MacVim/MacVim.pkg.recipe
@@ -70,39 +70,39 @@
         </dict>
         <dict>
             <key>Comment</key>
-            <string>Copy mvim to /usr/local/bin</string>
+            <string>Symlink /Applications/MacVim.app/Contents/bin/mvim to /usr/local/bin/vim</string>
             <key>Processor</key>
-            <string>Copier</string>
+            <string>Symlinker</string>
             <key>Arguments</key>
             <dict>
                 <key>source_path</key>
-                <string>%pathname%/MacVim.app/Contents/bin/mvim</string>
+                <string>/Applications/MacVim.app/Contents/bin/mvim</string>
                 <key>destination_path</key>
                 <string>%pkgroot%/usr/local/bin/mvim</string>
             </dict>
         </dict>
         <dict>
             <key>Comment</key>
-            <string>Symlink /usr/local/bin/mvim to /usr/local/bin/vim</string>
+            <string>Symlink /Applications/MacVim.app/Contents/bin/mvim to /usr/local/bin/vim</string>
             <key>Processor</key>
             <string>Symlinker</string>
             <key>Arguments</key>
             <dict>
                 <key>source_path</key>
-                <string>/usr/local/bin/mvim</string>
+                <string>/Applications/MacVim.app/Contents/bin/mvim</string>
                 <key>destination_path</key>
                 <string>%pkgroot%/usr/local/bin/vim</string>
             </dict>
         </dict>
         <dict>
             <key>Comment</key>
-            <string>Symlink /usr/local/bin/mvim to /usr/local/bin/vi</string>
+            <string>Symlink /Applications/MacVim.app/Contents/bin/mvim to /usr/local/bin/vi</string>
             <key>Processor</key>
             <string>Symlinker</string>
             <key>Arguments</key>
             <dict>
                 <key>source_path</key>
-                <string>/usr/local/bin/mvim</string>
+                <string>/Applications/MacVim.app/Contents/bin/mvim</string>
                 <key>destination_path</key>
                 <string>%pkgroot%/usr/local/bin/vi</string>
             </dict>

--- a/MacVim/MacVim.pkg.recipe
+++ b/MacVim/MacVim.pkg.recipe
@@ -4,8 +4,8 @@
 <dict>
     <key>Description</key>
     <string>Downloads the current release version of MacVim where MAJOR_OS_VERSION is Snow-Leopard, Mountain-Lion or Mavericks (default).</string>
-	<key>Identifier</key>
-	<string>com.github.jleggat.MacVim.pkg</string>
+    <key>Identifier</key>
+    <string>com.github.jleggat.MacVim.pkg</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>
@@ -21,33 +21,18 @@
     <array>
         <dict>
             <key>Processor</key>
-            <string>Unarchiver</string>
+            <string>PlistReader</string>
             <key>Arguments</key>
             <dict>
-                <key>archive_path</key>
-                <string>%pathname%</string>
-                <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/source</string>
-                <key>purge_destination</key>
-                <true/>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>FileFinder</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pattern</key>
-                <string>%RECIPE_CACHE_DIR%/source/MacVim-*</string>
-            </dict>
-        </dict>
-         <dict>
-            <key>Processor</key>
-            <string>Versioner</string>
-            <key>Arguments</key>
-            <dict>
-                <key>input_plist_path</key>
-                <string>%found_filename%/MacVim.app/Contents/Info.plist</string>
+                <key>info_path</key>
+                <string>%pathname%/MacVim.app/Contents/Info.plist</string>
+                <key>plist_keys</key>
+                <dict>
+                    <key>CFBundleShortVersionString</key>
+                    <string>version</string>
+                    <key>LSMinimumSystemVersion</key>
+                    <string>min_os_version</string>
+                </dict>
             </dict>
         </dict>
         <dict>
@@ -56,7 +41,7 @@
             <key>Arguments</key>
             <dict>
                 <key>pkgroot</key>
-                <string>%RECIPE_CACHE_DIR%/build/%NAME%</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
                 <key>pkgdirs</key>
                 <dict>
                     <key>Applications</key>
@@ -78,7 +63,7 @@
             <key>Arguments</key>
             <dict>
                 <key>source_path</key>
-                <string>%found_filename%/MacVim.app</string>
+                <string>%pathname%/MacVim.app</string>
                 <key>destination_path</key>
                 <string>%pkgroot%/Applications/MacVim.app</string>
             </dict>
@@ -91,7 +76,7 @@
             <key>Arguments</key>
             <dict>
                 <key>source_path</key>
-                <string>%found_filename%/mvim</string>
+                <string>%pathname%/MacVim.app/Contents/bin/mvim</string>
                 <key>destination_path</key>
                 <string>%pkgroot%/usr/local/bin/mvim</string>
             </dict>
@@ -131,10 +116,10 @@
             <dict>
                 <key>pkg_request</key>
                 <dict>
-        	        <key>pkgname</key>
-        	        <string>%NAME%-%version%</string>
-                	<key>version</key>
-                	<string>%version%</string>
+                    <key>pkgname</key>
+                    <string>%NAME%-%version%</string>
+                    <key>version</key>
+                    <string>%version%</string>
                     <key>id</key>
                     <string>%BUNDLEID%</string>
                     <key>chown</key>
@@ -162,8 +147,8 @@
                             <string>root</string>
                             <key>group</key>
                             <string>wheel</string>
-				<key>mode</key>
-				<string>0755</string>
+                            <key>mode</key>
+                            <string>0755</string>
                         </dict>
                     </array>
                 </dict>

--- a/MacVim/MacVimpkg.munki.recipe
+++ b/MacVim/MacVimpkg.munki.recipe
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the current release version of MacVim where MAJOR_OS_VERSION is Snow-Leopard, Mountain-Lion or Mavericks (default).</string>
+    <key>Identifier</key>
+    <string>com.github.jleggat.MacVimpkg.munki</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>MacVim</string>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>apps</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>catalogs</key>
+            <array>
+                <string>testing</string>
+            </array>
+            <key>category</key>
+            <string>Text Editors</string>
+            <key>description</key>
+            <string>MacVim supports multiple windows with tabbed editing and a host of other features such as:
+
+* bindings to standard OS X keyboard shortcuts,
+* transparent backgrounds,
+* full-screen mode,
+* multibyte editing with OS X input methods and automatic font substitution,
+* ODB editor support,
+
+and more. Most importantly, MacVim brings you the full power of Vim 7.4 to Mac OS X.</string>
+            <key>developer</key>
+            <string>Björn Winckler</string>
+            <key>display_name</key>
+            <string>Vim - the text editor - for Mac OS X </string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>unattended_install</key>
+            <true/>
+        </dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>0.3.0</string>
+    <key>ParentRecipe</key>
+    <string>com.github.jleggat.MacVim.pkg</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>minimum_os_version</key>
+                    <string>%min_os_version%</string>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%pkg_path%</string>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+        </dict>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
My apologies, when I submitted the PR I did not test all the way through to the munki recipe ...

This may be more my own opinion, but generally for munki recipes I prefer to leave drag-and-drop apps alone and just import them.  If there are any binaries or things within the app that need to be copied, symlinked, etc., that can be easily handled via a postinstall script.  As it is now, your munki recipe leans on the pkg recipe, which assumes that an admin would want to copy out and symlink those binaries.

To achieve both ends, I made the following changes:

**MacVim.pkg.recipe**
- Remove extraneous Unarchiver processor
- Replace Versioner with PlistReader.  Since you're building a PKG when importing into munki you lose the LSMinimumSystemVersion available if you just import the pkg as is.  This collects it for later importing
- Instead of copying out `mvim` to `/usr/local/bin` and symlinking, opt instead to symlink to the mvim binary within the app.  This way, should a user manually update the app and `mvim` is also updated the symlinks will still point to the newer binary, rather than the one you currently copy out and symlink to.

**MacVim.munki.recipe**
- Just import MacVim within the DMG.  For those who may not care or want to deploy a PKG with the macvim binary item and symlinks

**MacVimpkg.munki.recipe**
- Handles the previously configured workflow importing the created PKG
- Adds MunkiPkginfoMerger to use the previously collected minimum os version