### PR TITLE
Add blocking app for Wireshark

### DIFF
--- a/Wireshark/Wireshark.munki.recipe
+++ b/Wireshark/Wireshark.munki.recipe
@@ -14,6 +14,10 @@
 		<string>Wireshark</string>
 		<key>pkginfo</key>
 		<dict>
+			<key>blocking_applications</key>
+			<array>
+				<string>Wireshark.app</string>
+			</array>
 			<key>catalogs</key>
 			<array>
 				<string>testing</string>


### PR DESCRIPTION
Since Wireshark is being installed from a pkg, Munki does not automatically infer blocking applications.