### PR TITLE
Add blocking app for Fetch

### DIFF
--- a/Fetch/Fetch.munki.recipe
+++ b/Fetch/Fetch.munki.recipe
@@ -23,6 +23,10 @@ Set REGISTRANTNAME to name used to register a Fetch license agreement.</string>
 		<string>/Applications</string>
 		<key>pkginfo</key>
 		<dict>
+			<key>blocking_applications</key>
+			<array>
+				<string>Fetch.app</string>
+			</array>
 			<key>catalogs</key>
 			<array>
 				<string>testing</string>


### PR DESCRIPTION
Since Fetch is being installed from a pkg, Munki does not automatically infer blocking applications.

