### PR TITLE
update regex for Git recipe

### DIFF
--- a/Git/Git.download.recipe
+++ b/Git/Git.download.recipe
@@ -15,10 +15,8 @@ Note: Code signature verification on Git cannot be done at this time.</string>
 		<string>Git</string>
         	<key>DOWNLOAD_URL</key>
         	<string>https://sourceforge.net/projects/git-osx-installer/files/</string>
-        	<key>MAJOR_OS_VERSION</key>
-        	<string></string>
         	<key>SEARCH_PATTERN</key>
-            <string>href="(.*/projects/git-osx-installer/files/git-.*%MAJOR_OS_VERSION%\.dmg.*)"</string>
+            <string>href="(https:\/\/sourceforge.net\/projects\/git-osx-installer\/files\/git-[\.\d]+-intel-universal-mavericks\.dmg\/download)"</string>
 	</dict>
 	<key>Process</key>
 	<array>


### PR DESCRIPTION
The recipe started to fail with the old regex. Because the name of the `MAJOR_OS_VERSION` has not changed for 6 years so that is probably fine to hard code it into the regex. Making the regex more specific should allow it to be more consistent while the flexibility for new versions is still there.

Output for `autopkg run -vv com.github.jleggat.Git.download`:

```
Processing com.github.jleggat.Git.download...
WARNING: com.github.jleggat.Git.download is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href="(https:\\/\\/sourceforge.net\\/projects\\/git-osx-installer\\/files\\/git-[\\.\\d]+-intel-universal-mavericks\\.dmg\\/download)"',
           'url': 'https://sourceforge.net/projects/git-osx-installer/files/'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): https://sourceforge.net/projects/git-osx-installer/files/git-2.33.0-intel-universal-mavericks.dmg/download
{'Output': {'match': 'https://sourceforge.net/projects/git-osx-installer/files/git-2.33.0-intel-universal-mavericks.dmg/download'}}
URLDownloader
{'Input': {'filename': 'Git.dmg',
           'url': 'https://sourceforge.net/projects/git-osx-installer/files/git-2.33.0-intel-universal-mavericks.dmg/download'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Mon, 30 Aug 2021 16:53:28 GMT
URLDownloader: Storing new ETag header: "612d0d08-1a55fbb"
URLDownloader: Downloaded /Users/user/Library/AutoPkg/Cache/com.github.jleggat.Git.download/downloads/Git.dmg
{'Output': {'download_changed': True,
            'etag': '"612d0d08-1a55fbb"',
            'last_modified': 'Mon, 30 Aug 2021 16:53:28 GMT',
            'pathname': '/Users/user/Library/AutoPkg/Cache/com.github.jleggat.Git.download/downloads/Git.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/user/Library/AutoPkg/Cache/com.github.jleggat.Git.download/downloads/Git.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to /Users/user/Library/AutoPkg/Cache/com.github.jleggat.Git.download/receipts/com.github.jleggat.Git-receipt-20220317-160114.plist

The following new items were downloaded:
    Download Path                                                                            
    -------------                                                                            
    /Users/user/Library/AutoPkg/Cache/com.github.jleggat.Git.download/downloads/Git.dmg  
``` 

