### PR TITLE
Use GitHubReleasesInfoProvider for Pandoc

### DIFF
--- a/Pandoc/Pandoc.download.recipe
+++ b/Pandoc/Pandoc.download.recipe
@@ -10,34 +10,31 @@
 	<dict>
 		<key>NAME</key>
 		<string>Pandoc</string>
-		<key>SEARCH_PATTERN</key>
-		<string>(?P&lt;url&gt;/jgm/pandoc/releases/download/(?P&lt;version&gt;.*?)/pandoc-.*?.pkg)</string>
-		<key>SEARCH_URL</key>
-		<string>https://github.com/jgm/pandoc/releases</string>
+		<key>GITHUB_REPO</key>
+		<string>jgm/pandoc</string>
+		<key>ASSET_REGEX</key>
+		<string>pandoc-.*-macOS.pkg</string>
+		<key>INCLUDE_PRERELEASES</key>
+		<string></string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.4.2</string>
+	<string>0.5.0</string>
 	<key>Process</key>
 	<array>
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>re_pattern</key>
-				<string>%SEARCH_PATTERN%</string>
-				<key>url</key>
-				<string>%SEARCH_URL%</string>
+				<key>asset_regex</key>
+				<string>%ASSET_REGEX%</string>
+				<key>github_repo</key>
+				<string>%GITHUB_REPO%</string>
+				<key>include_prereleases</key>
+				<string>%INCLUDE_PRERELEASES%</string>
 			</dict>
 			<key>Processor</key>
-			<string>URLTextSearcher</string>
+			<string>GitHubReleasesInfoProvider</string>
 		</dict>
 		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>filename</key>
-				<string>%NAME%-%version%.pkg</string>
-				<key>url</key>
-				<string>https://github.com%url%</string>
-			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
 		</dict>


### PR DESCRIPTION
I think github changed the releaes html template and pandoc fails to download. Used this moment to upgrade from generic URLDownloader code to GithubReleaseInfoProvider.

Example run:

```
autopkg  run -vv --ignore-parent-trust-verification-errors Pandoc.munki.recipe 

Processing Pandoc.munki.recipe...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': 'pandoc-.*-macOS.pkg',
           'github_repo': 'jgm/pandoc',
           'include_prereleases': ''}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex 'pandoc-.*-macOS.pkg' among asset(s): pandoc-2.19.2-1-amd64.deb, pandoc-2.19.2-1-arm64.deb, pandoc-2.19.2-linux-amd64.tar.gz, pandoc-2.19.2-linux-arm64.tar.gz, pandoc-2.19.2-macOS.pkg, pandoc-2.19.2-macOS.zip, pandoc-2.19.2-windows-x86_64.msi, pandoc-2.19.2-windows-x86_64.zip
GitHubReleasesInfoProvider: Selected asset 'pandoc-2.19.2-macOS.pkg' from release 'pandoc 2.19.2'
{'Output': {'asset_url': 'https://api.github.com/repos/jgm/pandoc/releases/assets/75513481',
            'release_notes': '<details>\r\n'
                             '  <summary>Click to expand '
                             'changelog</summary>\r\n'
                             '\r\n'
                             '- Fix regression with data uris in 2.19.1 '
                             '(#8239). In 2.19.1 we used the base64URL '
                             'encoding rather than base64.\r\n'
                             '\r\n'
                             '- pandoc-server: handle `citeproc` parameter as '
                             'documented (#8235).\r\n'
                             '\r\n'
                             '- Org reader: treat *emacs-jupyter* src blocks '
                             'as code cells (#8236, Albert Krewinkel). This '
                             'improves support for notebook-like org files '
                             'that are intended to be used with emacs-jupyter '
                             'package.\r\n'
                             '\r\n'
                             '- HTML writer and templates: revert to using '
                             '`width` property for column widths (Albert '
                             'Krewinkel). The default `flex` and `overflow-x` '
                             'properties of a column are set to `auto`. In '
                             'combination, these changes allow to get good '
                             'results when using columns with or without '
                             'explicit widths.\r\n'
                             '\r\n'
                             '- Org writer (Albert Krewinkel):\r\n'
                             '\r\n'
                             '  - Add support for jupyter nodebook cells '
                             '(#6367).\r\n'
                             '  - Prefix code language of ipynb code blocks '
                             'with `jupyter-`. This is the convention used by '
                             'the *emacs-jupyter* package.\r\n'
                             '  - Keep code block attributes as header args. '
                             'This allows to keep more information in the '
                             'resulting `src` blocks, making it easier to '
                             'roundtrip from or through Org. Org babel ignores '
                             'unknown header arguments.\r\n'
                             '  - Add code block identifier as `#+name` to src '
                             'blocks.\r\n'
                             '\r\n'
                             '- Fix some typos in the codebase (luz paz).\r\n'
                             '\r\n'
                             '- Require hslua-module-path 1.0.3 (#8228, Albert '
                             'Krewinkel).\r\n'
                             '\r\n'
                             '</details>\r\n',
            'url': 'https://github.com/jgm/pandoc/releases/download/2.19.2/pandoc-2.19.2-macOS.pkg',
            'version': '2.19.2'}}
URLDownloader
{'Input': {'url': 'https://github.com/jgm/pandoc/releases/download/2.19.2/pandoc-2.19.2-macOS.pkg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/admin/Library/AutoPkg/Cache/local.munki.Pandoc/downloads/pandoc-2.19.2-macOS.pkg
{'Output': {'pathname': '/Users/admin/Library/AutoPkg/Cache/local.munki.Pandoc/downloads/pandoc-2.19.2-macOS.pkg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: John '
                                        'Macfarlane (5U2WKE6DES)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '/Users/admin/Library/AutoPkg/Cache/local.munki.Pandoc/downloads/pandoc-2.19.2-macOS.pkg'}}
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "pandoc-2.19.2-macOS.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2022-08-22 18:43:35 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: John Macfarlane (5U2WKE6DES)
CodeSignatureVerifier:        Expires: 2025-07-01 04:01:03 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B3 2C E1 F5 9D 1A 1A A5 D9 C0 41 D1 B9 33 4D 78 D1 FE 03 12 6D 1B 
CodeSignatureVerifier:            E4 A5 D0 D9 42 01 75 6C 3A 76
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/mnt/munkipkgs/',
           'pkg_path': '/Users/admin/Library/AutoPkg/Cache/local.munki.Pandoc/downloads/pandoc-2.19.2-macOS.pkg',
           'pkginfo': {'catalogs': ['production'],
                       'category': 'Scientific Writing',
                       'description': 'If you need to convert files from one '
                                      'markup format into another, pandoc is '
                                      'your swiss-army knife. ',
                       'developer': 'DEVELOPER',
                       'display_name': 'Pandoc a universal document converter',
                       'name': 'Pandoc',
                       'unattended_install': True},
           'repo_subdirectory': 'utilities'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /mnt/munkipkgs/
MunkiImporter: Item pandoc-2.19.2-macOS.pkg already exists in the munki repo as pkgs/utilities/Pandoc-2.19.2.pkg.
{'Output': {'pkg_repo_path': '/mnt/munkipkgs/pkgs/utilities/Pandoc-2.19.2.pkg'}}
Receipt written to /Users/admin/Library/AutoPkg/Cache/local.munki.Pandoc/receipts/Pandoc.munki-receipt-20220920-093523.plist

Nothing downloaded, packaged or imported.
```