### PR TITLE
Use GitHubReleasesInfoProvider for MunkiAdmin

### DIFF
--- a/MunkiAdmin/MunkiAdmin.download.recipe
+++ b/MunkiAdmin/MunkiAdmin.download.recipe
@@ -2,39 +2,39 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>Description</key>
-    <string>Download recipe for MunkiAdmin.</string>
-    <key>Identifier</key>
-    <string>com.github.jleggat.MunkiAdmin.download</string>
-    <key>Input</key>
-    <dict>
-        <key>NAME</key>
-        <string>MunkiAdmin</string>
-        <key>DOWNLOAD_URL</key>
-        <string>https://github.com</string>
-    </dict>
-    <key>MinimumVersion</key>
-    <string>0.2.0</string>
-    <key>Process</key>
-    <array>
-        <dict>
-            <key>Processor</key>
-            <string>URLTextSearcher</string>
-            <key>Arguments</key>
-            <dict>
-                <key>url</key>
-                <string>%DOWNLOAD_URL%/hjuutilainen/munkiadmin/releases</string>
-                <key>re_pattern</key>
-                <string>/hjuutilainen/munkiadmin/releases/download/.*\.dmg</string>
-            </dict>
-        </dict>
+	<key>Description</key>
+	<string>Download recipe for MunkiAdmin.</string>
+	<key>Identifier</key>
+	<string>com.github.jleggat.MunkiAdmin.download</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>MunkiAdmin</string>
+		<key>DOWNLOAD_URL</key>
+		<string>https://github.com</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.2.0</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>URLTextSearcher</string>
+			<key>Arguments</key>
+			<dict>
+				<key>url</key>
+				<string>%DOWNLOAD_URL%/hjuutilainen/munkiadmin/releases</string>
+				<key>re_pattern</key>
+				<string>/hjuutilainen/munkiadmin/releases/download/.*\.dmg</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-                <string>%DOWNLOAD_URL%%match%</string>
+				<string>%DOWNLOAD_URL%%match%</string>
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
 			</dict>
@@ -54,6 +54,6 @@
 				<string>anchor apple generic and identifier "com.hjuutilainen.MunkiAdmin" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "8XXWJ76X9Y")</string>
 			</dict>
 		</dict>
-    </array>
+	</array>
 </dict>
 </plist>

--- a/MunkiAdmin/MunkiAdmin.download.recipe
+++ b/MunkiAdmin/MunkiAdmin.download.recipe
@@ -10,34 +10,33 @@
 	<dict>
 		<key>NAME</key>
 		<string>MunkiAdmin</string>
-		<key>DOWNLOAD_URL</key>
-		<string>https://github.com</string>
+		<key>GITHUB_REPO</key>
+		<string>hjuutilainen/munkiadmin</string>
+		<key>ASSET_REGEX</key>
+		<string>MunkiAdmin.*dmg</string>
+		<key>INCLUDE_PRERELEASES</key>
+		<string></string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<string>0.5.0</string>
 	<key>Process</key>
 	<array>
 		<dict>
 			<key>Processor</key>
-			<string>URLTextSearcher</string>
+			<string>GitHubReleasesInfoProvider</string>
 			<key>Arguments</key>
 			<dict>
-				<key>url</key>
-				<string>%DOWNLOAD_URL%/hjuutilainen/munkiadmin/releases</string>
-				<key>re_pattern</key>
-				<string>/hjuutilainen/munkiadmin/releases/download/.*\.dmg</string>
+				<key>asset_regex</key>
+				<string>%ASSET_REGEX%</string>
+				<key>github_repo</key>
+				<string>%GITHUB_REPO%</string>
+				<key>include_prereleases</key>
+				<string>%INCLUDE_PRERELEASES%</string>
 			</dict>
 		</dict>
 		<dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
-			<key>Arguments</key>
-			<dict>
-				<key>url</key>
-				<string>%DOWNLOAD_URL%%match%</string>
-				<key>filename</key>
-				<string>%NAME%.dmg</string>
-			</dict>
 		</dict>
 		<dict>
 			<key>Processor</key>


### PR DESCRIPTION
Similar to #109

Also retabbed the file to have consistent tabs (had some softtabs/spaces in it)

Example run:

```
autopkg  run -vv --ignore-parent-trust-verification-errors  MunkiAdmin.munki.recipe


Processing MunkiAdmin.munki.recipe...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': 'MunkiAdmin.*.dmg',
           'github_repo': 'hjuutilainen/munkiadmin',
           'include_prereleases': ''}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex 'MunkiAdmin.*.dmg' among asset(s): MunkiAdmin-1.8.1.dmg
GitHubReleasesInfoProvider: Selected asset 'MunkiAdmin-1.8.1.dmg' from release 'MunkiAdmin 1.8.1 (the MacDevOpsYVR edition)'
{'Output': {'asset_url': 'https://api.github.com/repos/hjuutilainen/munkiadmin/releases/assets/38382314',
            'release_notes': '### Changes and fixes from 1.8.0 beta 2:\r\n'
                             '- Fixed compatibility with macOS 10.13\r\n'
                             '\r\n'
                             '### New and changed from 1.7\r\n'
                             '- MunkiAdmin is now an universal app and runs '
                             'natively on Apple Silicon\r\n'
                             '- Manifest editor now supports template '
                             'conditions and showing conditions from other '
                             'manifests\r\n'
                             '- MunkiAdmin now requires macOS 10.13 or '
                             'later\r\n'
                             '- Fix the display glitches in the main '
                             'toolbar\r\n'
                             '- Update most of the icons (sidebars, toolbars, '
                             'etc.) to use Apple SF Symbols\r\n'
                             '- Added new macOS version strings for '
                             'autocomplete\r\n'
                             '- Added new package list column for supported '
                             'architectures\r\n'
                             '- Initial support for custom manifest scripts\r\n'
                             '- Changed manifest list default visible '
                             'columns\r\n'
                             '- Block receiving events in the main window '
                             'while pkginfo editor is open\r\n'
                             '- Fix clipped text fields in manifest CSV import '
                             'view\r\n'
                             '- Lots of changes and refactoring under the '
                             'hood\r\n'
                             '- Fix incorrect text field width in manifest '
                             'editor\r\n'
                             '- Added support for `--skip-pkg-check` '
                             'makecatalogs option\r\n',
            'url': 'https://github.com/hjuutilainen/munkiadmin/releases/download/v1.8.1/MunkiAdmin-1.8.1.dmg',
            'version': '1.8.1'}}
URLDownloader
{'Input': {'url': 'https://github.com/hjuutilainen/munkiadmin/releases/download/v1.8.1/MunkiAdmin-1.8.1.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 08 Dec 2021 08:48:41 GMT
URLDownloader: Storing new ETag header: "0x8D9BA2788FF0569"
URLDownloader: Downloaded /Users/admin/Library/AutoPkg/Cache/local.munki.MunkiAdmin/downloads/MunkiAdmin-1.8.1.dmg
{'Output': {'download_changed': True,
            'etag': '"0x8D9BA2788FF0569"',
            'last_modified': 'Wed, 08 Dec 2021 08:48:41 GMT',
            'pathname': '/Users/admin/Library/AutoPkg/Cache/local.munki.MunkiAdmin/downloads/MunkiAdmin-1.8.1.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/admin/Library/AutoPkg/Cache/local.munki.MunkiAdmin/downloads/MunkiAdmin-1.8.1.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/admin/Library/AutoPkg/Cache/local.munki.MunkiAdmin/downloads/MunkiAdmin-1.8.1.dmg/MunkiAdmin.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.hjuutilainen.MunkiAdmin" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "8XXWJ76X9Y")'}}
CodeSignatureVerifier: Mounted disk image /Users/admin/Library/AutoPkg/Cache/local.munki.MunkiAdmin/downloads/MunkiAdmin-1.8.1.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.QoZn2w/MunkiAdmin.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.QoZn2w/MunkiAdmin.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.QoZn2w/MunkiAdmin.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/mnt/munkipkgs/',
           'additional_makepkginfo_options': ['--destinationpath',
                                              '/Applications'],
           'pkg_path': '/Users/admin/Library/AutoPkg/Cache/local.munki.MunkiAdmin/downloads/MunkiAdmin-1.8.1.dmg',
           'pkginfo': {'catalogs': ['production'],
                       'category': 'Munki Tools',
                       'description': 'MunkiAdmin is a GUI for managing munki '
                                      'repositories. It is written with '
                                      'Objective-C and uses in-memory Core '
                                      'Data store as a backend.',
                       'developer': 'Hannes Juutilainen',
                       'display_name': 'MunkiAdmin - GUI tools for Munki',
                       'name': 'MunkiAdmin',
                       'unattended_install': True},
           'repo_subdirectory': 'apps'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /mnt/munkipkgs/
MunkiImporter: Item MunkiAdmin-1.8.1.dmg already exists in the munki repo as pkgs/apps/MunkiAdmin-1.8.1.dmg.
{'Output': {'pkg_repo_path': '/mnt/munkipkgs/pkgs/apps/MunkiAdmin-1.8.1.dmg'}}
Receipt written to /Users/admin/Library/AutoPkg/Cache/local.munki.MunkiAdmin/receipts/MunkiAdmin.munki-receipt-20220920-095748.plist

The following new items were downloaded:
    Download Path                                                                             
    -------------                                                                             
    /Users/admin/Library/AutoPkg/Cache/local.munki.MunkiAdmin/downloads/MunkiAdmin-1.8.1.dmg  
```