### PR TITLE
Update Fetch.munki.recipe

### DIFF
--- a/Fetch/Fetch.munki.recipe
+++ b/Fetch/Fetch.munki.recipe
@@ -5,16 +5,20 @@
     <key>Description</key>
     <string>Downloads the latest Fetch from Fetch Softworks website, creates a Apple installer pkg and imports into Munki.
 
-Optional Values SERIALNUMBER and REGISTRANTNAME when both provided will 
-add a fetch license agreement to 
+Optional Values SERIALNUMBER and REGISTRANTNAME when both provided will
+add a fetch license agreement to
 /Library/Preferences/com.fetchsoftworks.Fetch.License.plist.
 
 Set SERIALNUMBER to serial number provided in a Fetch license agreement.
-Set REGISTRANTNAME to name used to register a Fetch license agreement.</string>
+Set REGISTRANTNAME to name used to register a Fetch license agreement.
+
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
     <key>Identifier</key>
     <string>com.github.jleggat.Fetch.munki</string>
     <key>Input</key>
     <dict>
+        <key>DERIVE_MIN_OS</key>
+        <string>YES</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/Fetch</string>
         <key>NAME</key>
@@ -45,6 +49,8 @@ Set REGISTRANTNAME to name used to register a Fetch license agreement.</string>
             <string>Fetch Softworks</string>
         </dict>
     </dict>
+    <key>MinimumVersion</key>
+    <string>2.7</string>
     <key>ParentRecipe</key>
     <string>com.github.jleggat.pkg.Fetch</string>
     <key>Process</key>
@@ -60,6 +66,8 @@ Set REGISTRANTNAME to name used to register a Fetch license agreement.</string>
                 <array>
                     <string>/Applications/Fetch.app</string>
                 </array>
+                <key>derive_minimum_os_version</key>
+                <string>%DERIVE_MIN_OS%</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
Hi, @onecooltaco 

The Fetch Munki recipe currently doesn't set the `minimum_os_version` from the App's info.plist, and as such a default value of 10.5.0 is being set.

This PR adds in support for the new `derive_minimum_os_version` key in the `MunkiInstallsItemsCreator` processor. With this set the min_os_version becomes 10.13

This change requires AutoPkg version 2.7 or higher, if compatibility with older versions of AutoPkg is needed, the same result could be achieved with something like below.

```
        <dict>
            <key>Arguments</key>
            <dict>
                <key>info_path</key>
                <string>%RECIPE_CACHE_DIR%/Applications/APP_NAME.app</string>
                <key>plist_keys</key>
                <dict>
                    <key>LSMinimumSystemVersion</key>
                    <string>min_os_ver</string>
                </dict>
            </dict>
            <key>Processor</key>
            <string>PlistReader</string>
        </dict>
        <dict>
             <key>Arguments</key>
             <dict>
                <key>additional_pkginfo</key>
                <dict>
                    <key>minimum_os_version</key>
                    <string>%min_os_ver%</string>
                </dict>
            </dict>
            <key>Processor</key>
            <string>MunkiPkginfoMerger</string>
        </dict>
```

Output from a successful verbose run:

```
autopkg run -v /Users/paul/Documents/GitHub/AutoPkg\ Repos/jleggat-recipes/Fetch/Fetch.munki.recipe 
Processing /Users/paul/Documents/GitHub/AutoPkg Repos/jleggat-recipes/Fetch/Fetch.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/AutoPkg Repos/jleggat-recipes/Fetch/Fetch.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (url): fetch/download/Fetch_5.8.2.zip
URLTextSearcher: Found matching text (version): 5.8.2
URLTextSearcher: Found matching text (match): fetch/download/Fetch_5.8.2.zip
URLDownloader
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/paul/Library/AutoPkg/Cache/com.github.jleggat.Fetch.munki/downloads/Fetch-5.8.2.zip
EndOfCheckPhase
PkgRootCreator
PkgRootCreator: Created /Users/paul/Library/AutoPkg/Cache/com.github.jleggat.Fetch.munki/build
PkgRootCreator: Created /Users/paul/Library/AutoPkg/Cache/com.github.jleggat.Fetch.munki/build/Applications
Unarchiver
Unarchiver: Guessed archive format 'zip' from filename Fetch-5.8.2.zip
Unarchiver: Unarchived /Users/paul/Library/AutoPkg/Cache/com.github.jleggat.Fetch.munki/downloads/Fetch-5.8.2.zip to /Users/paul/Library/AutoPkg/Cache/com.github.jleggat.Fetch.munki/build/Applications/
FetchScriptsPath
FetchScriptsPath: Found Directory /Users/paul/Documents/GitHub/AutoPkg Repos/jleggat-recipes/Fetch/Scripts
Copier
Copier: Copied /Users/paul/Documents/GitHub/AutoPkg Repos/jleggat-recipes/Fetch/Scripts to /Users/paul/Library/AutoPkg/Cache/com.github.jleggat.Fetch.munki/Scripts
FileCreator
FileCreator: Created file at /Users/paul/Library/AutoPkg/Cache/com.github.jleggat.Fetch.munki/Scripts/conf.txt
PkgCreator
PkgCreator: Package already exists at path /Users/paul/Library/AutoPkg/Cache/com.github.jleggat.Fetch.munki/Fetch-5.8.2.pkg.
PkgCreator: Existing package matches version and identifier, not building.
MunkiInstallsItemsCreator
MunkiInstallsItemsCreator: Created installs item for /Applications/Fetch.app
MunkiInstallsItemsCreator: Derived minimum os version as: 10.13
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'com.fetchsoftworks.Fetch', 'CFBundleName': 'Fetch', 'CFBundleShortVersionString': '5.8.2', 'CFBundleVersion': '5.8.1354', 'minosversion': '10.13', 'path': '/Applications/Fetch.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}], 'minimum_os_version': '10.13'} into pkginfo
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/Fetch/Fetch-5.8.2__1.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Fetch/Fetch-5.8.2__1.pkg
PathDeleter
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/com.github.jleggat.Fetch.munki/build
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/com.github.jleggat.Fetch.munki/Scripts
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.jleggat.Fetch.munki/receipts/Fetch.munki-receipt-20221221-153215.plist

The following new items were imported into Munki:
    Name   Version  Catalogs  Pkginfo Path                     Pkg Repo Path                  Icon Repo Path  
    ----   -------  --------  ------------                     -------------                  --------------  
    Fetch  5.8.2    testing   apps/Fetch/Fetch-5.8.2__1.plist  apps/Fetch/Fetch-5.8.2__1.pkg  
```