### PR TITLE
Add ARCH input for pandoc to support arm64

### DIFF
--- a/Pandoc/Pandoc.download.recipe
+++ b/Pandoc/Pandoc.download.recipe
@@ -10,10 +10,12 @@
 	<dict>
 		<key>NAME</key>
 		<string>Pandoc</string>
+		<key>ARCH</key>
+		<string>x86_64</string>
 		<key>GITHUB_REPO</key>
 		<string>jgm/pandoc</string>
 		<key>ASSET_REGEX</key>
-		<string>pandoc-.*-macOS.pkg</string>
+		<string>pandoc-.*%ARCH%-macOS.pkg</string>
 		<key>INCLUDE_PRERELEASES</key>
 		<string></string>
 	</dict>

--- a/Pandoc/Pandoc.munki.recipe
+++ b/Pandoc/Pandoc.munki.recipe
@@ -8,6 +8,8 @@
 	<string>com.github.jleggat.munki.pandoc</string>
 	<key>Input</key>
 	<dict>
+		<key>ARCH</key>
+		<string>x86_64</string>
 		<key>MUNKI_CATEGORY</key>
 		<string>Developer Tools</string>
 		<key>MUNKI_REPO_SUBDIR</key>
@@ -30,6 +32,8 @@
 			<string>%NAME%</string>
 			<key>unattended_install</key>
 			<true/>
+			<key>supported_architecture</key>
+			<string>%ARCH%</string>
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>


### PR DESCRIPTION
Currently, pandoc breaks, because the github asset regex will prefer the arm64 package. This PR addes the ARCH input, so:

+ the default is restored (downloading x86_64)
+ users can create a second override with ARCH set to arm64 