### PR TITLE
Release URL changed

### DIFF
--- a/PostgresApp/PostgresApp.download.recipe
+++ b/PostgresApp/PostgresApp.download.recipe
@@ -13,7 +13,7 @@
         <!--Postgres.app with PostgreSQL 14 binary: https://postgresapp.com/sparkle/updates_14.xml
         Postgres.app with PostgreSQL 10, 11, 12, 13, 14 and 15 binaries: https://postgresapp.com/sparkle/updates_10_11_12_13_14_15.xml-->
         <key>release</key>
-        <string>https://postgresapp.com/sparkle/updates_10_11_12_13_14_15.xml</string>
+        <string>https://postgresapp.com/sparkle/updates_11_12_13_14_15_16.xml</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.0</string>


### PR DESCRIPTION
The release URL changed from
https://postgresapp.com/sparkle/updates_10_11_12_13_14_15.xml to
https://postgresapp.com/sparkle/updates_11_12_13_14_15_16.xml to include v16 and remove v10