### PR TITLE
Fix SQLite Browser recipes

### DIFF
--- a/sqlitebrowser/sqlitebrowser.download.recipe
+++ b/sqlitebrowser/sqlitebrowser.download.recipe
@@ -9,14 +9,14 @@
         <key>NAME</key>
         <string>sqlitebrowser</string>
         <key>DOWNLOAD_URL</key>
-        <string>http://sqlitebrowser.org</string>
+        <string>https://sqlitebrowser.org/dl/</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.0</string>
     <key>Process</key>
     <array>
-       <dict>
-	<key>Processor</key>
+        <dict>
+            <key>Processor</key>
             <string>URLTextSearcher</string>
             <key>Arguments</key>
             <dict>

--- a/sqlitebrowser/sqlitebrowser.download.recipe
+++ b/sqlitebrowser/sqlitebrowser.download.recipe
@@ -41,6 +41,17 @@
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
         </dict>
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pathname%/DB Browser for SQLite.app</string>
+                <key>requirement</key>
+                <string>identifier "net.sourceforge.sqlitebrowser" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = C34AV33YLK</string>
+            </dict>
+        </dict>
     </array>
 </dict>
 </plist>


### PR DESCRIPTION
This PR updates the download page for SQLite Browser (DB Browser for SQLite).

Verbose recipe run output:

```
% autopkg run -vvq 'sqlitebrowser/sqlitebrowser.download.recipe'
Processing sqlitebrowser/sqlitebrowser.download.recipe...
WARNING: sqlitebrowser/sqlitebrowser.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '[^"]+\\.dmg', 'url': 'https://sqlitebrowser.org/dl/'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): https://download.sqlitebrowser.org/DB.Browser.for.SQLite-v3.13.1.dmg
{'Output': {'match': 'https://download.sqlitebrowser.org/DB.Browser.for.SQLite-v3.13.1.dmg'}}
URLDownloader
{'Input': {'filename': 'sqlitebrowser.dmg',
           'url': 'https://download.sqlitebrowser.org/DB.Browser.for.SQLite-v3.13.1.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 16 Oct 2024 07:48:52 GMT
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.jleggat.sqlitebrowser.download/downloads/sqlitebrowser.dmg
{'Output': {'download_changed': True,
            'last_modified': 'Wed, 16 Oct 2024 07:48:52 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.jleggat.sqlitebrowser.download/downloads/sqlitebrowser.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.jleggat.sqlitebrowser.download/downloads/sqlitebrowser.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.jleggat.sqlitebrowser.download/downloads/sqlitebrowser.dmg/DB '
                         'Browser for SQLite.app',
           'requirement': 'identifier "net.sourceforge.sqlitebrowser" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'C34AV33YLK'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.jleggat.sqlitebrowser.download/downloads/sqlitebrowser.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.KRZBIC/DB Browser for SQLite.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.KRZBIC/DB Browser for SQLite.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.KRZBIC/DB Browser for SQLite.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.jleggat.sqlitebrowser.download/receipts/sqlitebrowser.download-receipt-20241226-201950.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.jleggat.sqlitebrowser.download/downloads/sqlitebrowser.dmg
```
