### PR TITLE
Fix pngout recipes

### DIFF
--- a/pngout/pngout.download.recipe
+++ b/pngout/pngout.download.recipe
@@ -11,9 +11,9 @@
         <key>NAME</key>
         <string>pngout</string>
         <key>DOWNLOAD_URL</key>
-        <string>http://www.jonof.id.au/kenutils</string>
+        <string>https://www.jonof.id.au/kenutils.html</string>
         <key>DOWNLOAD_PATTERN</key>
-       	<string>([^"]+pngout-(?P&lt;version&gt;[0-9]+)-darwin\.tar\.gz)</string>
+       	<string>href="/files/kenutils/pngout-(?P&lt;version&gt;[\d]+)-mac\.zip"</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.3</string>
@@ -27,7 +27,7 @@
                 <key>url</key>
                 <string>%DOWNLOAD_URL%</string>
                 <key>re_pattern</key>
-        	<string>%DOWNLOAD_PATTERN%</string>
+                <string>%DOWNLOAD_PATTERN%</string>
             </dict>
         </dict>
 		<dict>
@@ -36,9 +36,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-                <string>%match%</string>
+                <string>https://www.jonof.id.au/files/kenutils/pngout-%version%-mac.zip</string>
 				<key>filename</key>
-				<string>%NAME%.tar.gz</string>
+				<string>%NAME%.zip</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
This PR adjusts the download page and file pattern used to download `pngout`.

```
% autopkg run -vvq 'pngout/pngout.download.recipe'
Processing pngout/pngout.download.recipe...
WARNING: pngout/pngout.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href="/files/kenutils/pngout-(?P<version>[\\d]+)-mac\\.zip"',
           'url': 'https://www.jonof.id.au/kenutils.html'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (version): 20230322
URLTextSearcher: Found matching text (match): 20230322
{'Output': {'match': '20230322', 'version': '20230322'}}
URLDownloader
{'Input': {'filename': 'pngout.zip',
           'url': 'https://www.jonof.id.au/files/kenutils/pngout-20230322-mac.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 22 Mar 2023 07:33:13 GMT
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.jleggat.pngout.download/downloads/pngout.zip
{'Output': {'download_changed': True,
            'last_modified': 'Wed, 22 Mar 2023 07:33:13 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.jleggat.pngout.download/downloads/pngout.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.jleggat.pngout.download/downloads/pngout.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.jleggat.pngout.download/receipts/pngout.download-receipt-20241226-201245.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.jleggat.pngout.download/downloads/pngout.zip
```
