### PR TITLE
Deprecate pgAdmin3 recipes

### DIFF
--- a/pgAdmin3/pgAdmin3.download.recipe
+++ b/pgAdmin3/pgAdmin3.download.recipe
@@ -21,6 +21,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to one of the pgAdmin4 recipes in the bnpl-recipes or dataJAR-recipes repos. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>URLTextSearcher</string>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
This PR deprecates the non-functional pgAdmin3 recipes, since pgAdmin4 is now the latest version.
