### PR TITLE
Deprecate PackageUninstaller recipes

### DIFF
--- a/PackageUninstaller/PackageUninstaller.download.recipe
+++ b/PackageUninstaller/PackageUninstaller.download.recipe
@@ -19,6 +19,15 @@
 	<array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>PackageUninstaller is no longer maintained (details: https://github.com/hewigovens/PackageUninstaller). This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>URLTextSearcher</string>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
This PR deprecates the PackageUninstaller recipes, because the software is no longer available for download.
