### PR TITLE
Fix `ne` recipes and add ARCH input variable

### DIFF
--- a/ne/ne.download.recipe
+++ b/ne/ne.download.recipe
@@ -3,17 +3,24 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads ne text editor for OS X dmg.</string>
+	<string>Downloads ne text editor for OS X dmg.
+	
+Valid values for ARCH include:
+- "Intel" (default)
+- "AppleSilicon"
+</string>
 	<key>Identifier</key>
 	<string>com.github.jleggat.ne.download</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>
 		<string>ne</string>
-        	<key>DOWNLOAD_URL</key>
-        	<string>http://ne.di.unimi.it</string>
-        	<key>SEARCH_PATTERN</key>
-		<string>(?P&lt;url&gt;[^"]+-(?P&lt;version&gt;[0-9\.]+)\.dmg)</string>
+		<key>ARCH</key>
+		<string>Intel</string>
+		<key>DOWNLOAD_URL</key>
+		<string>http://ne.di.unimi.it</string>
+		<key>SEARCH_PATTERN</key>
+		<string>(?P&lt;url&gt;[^"]+-(?P&lt;version&gt;[0-9\.]+)-%ARCH%\.dmg)</string>
 	</dict>
 	<key>Process</key>
 	<array>


### PR DESCRIPTION
This PR adjusts the `ne` download to support the new filename pattern, which is suffixed with either `Intel` or `AppleSilicon`.

Verbose recipe run with default (Intel) architecture:

```
% autopkg run -vvq 'ne/ne.download.recipe'
Processing ne/ne.download.recipe...
WARNING: ne/ne.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '(?P<url>[^"]+-(?P<version>[0-9\\.]+)-Intel\\.dmg)',
           'url': 'http://ne.di.unimi.it'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (url): ne-3.3.3-Intel.dmg
URLTextSearcher: Found matching text (version): 3.3.3
URLTextSearcher: Found matching text (match): ne-3.3.3-Intel.dmg
{'Output': {'match': 'ne-3.3.3-Intel.dmg',
            'url': 'ne-3.3.3-Intel.dmg',
            'version': '3.3.3'}}
URLDownloader
{'Input': {'filename': 'ne.dmg',
           'url': 'http://ne.di.unimi.it/ne-3.3.3-Intel.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Fri, 20 Oct 2023 05:45:42 GMT
URLDownloader: Storing new ETag header: "fb9ca-6081f62173a08"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.jleggat.ne.download/downloads/ne.dmg
{'Output': {'download_changed': True,
            'etag': '"fb9ca-6081f62173a08"',
            'last_modified': 'Fri, 20 Oct 2023 05:45:42 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.jleggat.ne.download/downloads/ne.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.jleggat.ne.download/downloads/ne.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.jleggat.ne.download/receipts/ne.download-receipt-20241226-195621.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.jleggat.ne.download/downloads/ne.dmg
```

Verbose recipe run with Apple Silicon architecture:

```
% autopkg run -vvq 'ne/ne.download.recipe' -k ARCH=AppleSilicon
Processing ne/ne.download.recipe...
WARNING: ne/ne.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '(?P<url>[^"]+-(?P<version>[0-9\\.]+)-AppleSilicon\\.dmg)',
           'url': 'http://ne.di.unimi.it'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (url): ne-3.3.3-AppleSilicon.dmg
URLTextSearcher: Found matching text (version): 3.3.3
URLTextSearcher: Found matching text (match): ne-3.3.3-AppleSilicon.dmg
{'Output': {'match': 'ne-3.3.3-AppleSilicon.dmg',
            'url': 'ne-3.3.3-AppleSilicon.dmg',
            'version': '3.3.3'}}
URLDownloader
{'Input': {'filename': 'ne.dmg',
           'url': 'http://ne.di.unimi.it/ne-3.3.3-AppleSilicon.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Fri, 20 Oct 2023 04:47:25 GMT
URLDownloader: Storing new ETag header: "fb424-6081e91a3eaf7"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.jleggat.ne.download/downloads/ne.dmg
{'Output': {'download_changed': True,
            'etag': '"fb424-6081e91a3eaf7"',
            'last_modified': 'Fri, 20 Oct 2023 04:47:25 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.jleggat.ne.download/downloads/ne.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.jleggat.ne.download/downloads/ne.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.jleggat.ne.download/receipts/ne.download-receipt-20241226-195634.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.jleggat.ne.download/downloads/ne.dmg
```
