### PR TITLE
Adjust Monit recipes to use new pkg download

### DIFF
--- a/Monit/Monit.download.recipe
+++ b/Monit/Monit.download.recipe
@@ -10,8 +10,6 @@
     <dict>
         <key>NAME</key>
         <string>Monit</string>
-        <key>SEARCH_URL</key>
-        <string>https://mmonit.com/monit/</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.3</string>
@@ -23,26 +21,39 @@
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>%SEARCH_URL%</string>
+                <string>https://mmonit.com/monit/</string>
                 <key>re_pattern</key>
-                <string>dist/binary/.*/monit-.*-macosx-universal\.tar\.gz</string>
+                <string>href="(dist/binary/[\d\.]+/monit-[\d\.]+-macos-x64\.pkg)"</string>
             </dict>
         </dict>
-		<dict>
-			<key>Processor</key>
-			<string>URLDownloader</string>
-			<key>Arguments</key>
-			<dict>
-				<key>url</key>
-                <string>%SEARCH_URL%%match%</string>
-				<key>filename</key>
-				<string>%NAME%.tar.gz</string>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>EndOfCheckPhase</string>
-		</dict>
+        <dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+            <key>Arguments</key>
+            <dict>
+                <key>url</key>
+                <string>https://mmonit.com/monit/%match%</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pathname%</string>
+                <key>expected_authority_names</key>
+                <array>
+                    <string>Developer ID Installer: Tildeslash (Z7D8RDKK69)</string>
+                    <string>Developer ID Certification Authority</string>
+                    <string>Apple Root CA</string>
+                </array>
+            </dict>
+        </dict>
     </array>
 </dict>
 </plist>

--- a/Monit/Monit.install.recipe
+++ b/Monit/Monit.install.recipe
@@ -14,7 +14,7 @@
     <key>MinimumVersion</key>
     <string>0.4.0</string>
     <key>ParentRecipe</key>
-    <string>com.github.jleggat.pkg.Monit</string>
+    <string>com.github.jleggat.download.Monit</string>
     <key>Process</key>
     <array>
         <dict>
@@ -23,7 +23,7 @@
             <key>Arguments</key>
             <dict>
                 <key>pkg_path</key>
-                <string>%pkg_path%</string>
+                <string>%pathname%</string>
             </dict>
         </dict>
     </array>

--- a/Monit/Monit.munki.recipe
+++ b/Monit/Monit.munki.recipe
@@ -53,7 +53,7 @@ exit 0</string>
             <key>Arguments</key>
             <dict>
                 <key>pkg_path</key>
-                <string>%pkg_path%</string>
+                <string>%pathname%</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
             </dict>

--- a/Monit/Monit.pkg.recipe
+++ b/Monit/Monit.pkg.recipe
@@ -8,8 +8,6 @@
     <dict>
         <key>NAME</key>
         <string>Monit</string>
-        <key>BUNDLEID</key>
-        <string>com.mmonit.Monit</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.3</string>
@@ -17,196 +15,17 @@
     <string>com.github.jleggat.download.Monit</string>
     <key>Process</key>
     <array>
+    <dict>
+        <key>Processor</key>
+        <string>PkgCopier</string>
+        <key>Arguments</key>
         <dict>
-            <key>Processor</key>
-            <string>Unarchiver</string>
-            <key>Arguments</key>
-            <dict>
-                <key>archive_path</key>
-                <string>%pathname%</string>
-                <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/source</string>
-                <key>purge_destination</key>
-                <true/>
-            </dict>
+            <key>source_pkg</key>
+            <string>%pathname%</string>
+            <key>destination_path</key>
+            <string>%RECIPE_CACHE_DIR%/%NAME%.pkg</string>
         </dict>
-        <dict>
-            <key>Processor</key>
-            <string>FileFinder</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pattern</key>
-                <string>%RECIPE_CACHE_DIR%/source/monit-*</string>
-            </dict>
-        </dict>
-         <dict>
-            <key>Processor</key>
-            <string>MonitVersioner</string>
-            <key>Arguments</key>
-            <dict>
-                <key>root_path</key>
-                <string>%found_filename%</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>PkgRootCreator</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pkgroot</key>
-                <string>%RECIPE_CACHE_DIR%/build/%NAME%</string>
-                <key>pkgdirs</key>
-                <dict>
-                    <key>private</key>
-                    <string>0755</string>
-                    <key>private/etc</key>
-                    <string>0755</string>
-                    <key>private/etc/monit.d</key>
-                    <string>0700</string>
-                    <key>private/var</key>
-                    <string>0755</string>
-                    <key>private/var/monit</key>
-                    <string>0700</string>
-                    <key>usr</key>
-                    <string>0755</string>
-                    <key>usr/share</key>
-                    <string>0755</string>
-                    <key>Library</key>
-                    <string>0755</string>
-                    <key>Library/LaunchDaemons</key>
-                    <string>0755</string>
-                </dict>
-            </dict>
-        </dict>
-        <dict>
-            <key>Comment</key>
-            <string>Copy monit bin folder to /usr/bin</string>
-            <key>Processor</key>
-            <string>Copier</string>
-            <key>Arguments</key>
-            <dict>
-                <key>source_path</key>
-                <string>%found_filename%/bin</string>
-                <key>destination_path</key>
-                <string>%pkgroot%/usr/bin</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Comment</key>
-            <string>Copy monit man folder to /usr/share/man</string>
-            <key>Processor</key>
-            <string>Copier</string>
-            <key>Arguments</key>
-            <dict>
-                <key>source_path</key>
-                <string>%found_filename%/man</string>
-                <key>destination_path</key>
-                <string>%pkgroot%/usr/share/man</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Comment</key>
-            <string>Copy monit conf/monitrc file to /private/etc/monitrc.default</string>
-            <key>Processor</key>
-            <string>Copier</string>
-            <key>Arguments</key>
-            <dict>
-                <key>source_path</key>
-                <string>%found_filename%/conf/monitrc</string>
-                <key>destination_path</key>
-                <string>%pkgroot%/private/etc/monitrc.default</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Comment</key>
-            <string>make launchd plist for monit at /Library/LaunchDaemons</string>
-            <key>Processor</key>
-            <string>PlistEditor</string>
-            <key>Arguments</key>
-            <dict>
-                <key>output_plist_path</key>
-                <string>%pkgroot%/Library/LaunchDaemons/com.mmonit.monit.plist</string>
-                <key>plist_data</key>
-				<dict>
-					<key>UserName</key>
-					<string>root</string>
-					<key>Label</key>
-					<string>com.mmonit.monit</string>
-					<key>OnDemand</key>
-					<false/>
-					<key>RunAtLoad</key>
-					<true/>
-					<key>ProgramArguments</key>
-					<array>
-						<string>/usr/bin/monit</string>
-						<string>-c</string>
-						<string>/etc/monitrc</string>
-						<string>-I</string>
-						<string>-l</string>
-						<string>/var/log/monit.log</string>
-					</array>
-				</dict>
-            </dict>
-        </dict>
-        <dict>
-            <key>Comment</key>
-            <string>Build the package</string>
-            <key>Processor</key>
-            <string>PkgCreator</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pkg_request</key>
-                <dict>
-                <key>pkgname</key>
-                <string>%NAME%-%version%</string>
-                <key>version</key>
-                <string>%version%</string>
-                    <key>pkgdir</key>
-                    <string>%RECIPE_CACHE_DIR%</string>
-                    <key>id</key>
-                    <string>%BUNDLEID%</string>
-                    <key>scripts</key>
-                    <string>Scripts</string>
-                    <key>chown</key>
-                    <array>
-                        <dict>
-                            <key>path</key>
-                            <string>private</string>
-                            <key>user</key>
-                            <string>root</string>
-                            <key>group</key>
-                            <string>admin</string>
-                        </dict>
-                        <dict>
-                            <key>path</key>
-                            <string>usr</string>
-                            <key>user</key>
-                            <string>root</string>
-                            <key>group</key>
-                            <string>wheel</string>
-                        </dict>
-                        <dict>
-                            <key>path</key>
-                            <string>Library</string>
-                            <key>user</key>
-                            <string>root</string>
-                            <key>group</key>
-                            <string>wheel</string>
-                        </dict>
-                        <dict>
-                            <key>path</key>
-                            <string>usr/bin/monit</string>
-                            <key>user</key>
-                            <string>root</string>
-                            <key>group</key>
-                            <string>wheel</string>
-				<key>mode</key>
-				<string>0755</string>
-                        </dict>
-                    </array>
-                </dict>
-            </dict>
-        </dict>
+    </dict>
     </array>
 </dict>
 </plist>


### PR DESCRIPTION
This PR adjusts the Monit recipes to use the new pkg download, which contains a Universal version of the Monit binary.

Verbose download/pkg/munki recipe run output:

```
% autopkg run -vvq Monit.{download,pkg,munki}.recipe
Processing Monit.download.recipe...
WARNING: Monit.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href="(dist/binary/[\\d\\.]+/monit-[\\d\\.]+-macos-x64\\.pkg)"',
           'url': 'https://mmonit.com/monit/'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): dist/binary/5.34.3/monit-5.34.3-macos-x64.pkg
{'Output': {'match': 'dist/binary/5.34.3/monit-5.34.3-macos-x64.pkg'}}
URLDownloader
{'Input': {'url': 'https://mmonit.com/monit/dist/binary/5.34.3/monit-5.34.3-macos-x64.pkg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 10 Dec 2024 17:16:08 GMT
URLDownloader: Storing new ETag header: "1a62e9d-3814dc-628eda3145710"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.jleggat.download.Monit/downloads/monit-5.34.3-macos-x64.pkg
{'Output': {'download_changed': True,
            'etag': '"1a62e9d-3814dc-628eda3145710"',
            'last_modified': 'Tue, 10 Dec 2024 17:16:08 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.jleggat.download.Monit/downloads/monit-5.34.3-macos-x64.pkg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.jleggat.download.Monit/downloads/monit-5.34.3-macos-x64.pkg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Tildeslash '
                                        '(Z7D8RDKK69)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/com.github.jleggat.download.Monit/downloads/monit-5.34.3-macos-x64.pkg'}}
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "monit-5.34.3-macos-x64.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2024-12-10 16:37:40 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Tildeslash (Z7D8RDKK69)
CodeSignatureVerifier:        Expires: 2025-11-15 16:20:43 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            01 80 D1 CA 2A 63 73 CF 73 F9 3E 51 E2 87 A0 CB 63 04 CA 62 36 16
CodeSignatureVerifier:            E2 25 58 1E 2C 8C 45 A4 B9 0A
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.jleggat.download.Monit/receipts/Monit.download-receipt-20241226-195157.plist
Processing Monit.pkg.recipe...
WARNING: Monit.pkg.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href="(dist/binary/[\\d\\.]+/monit-[\\d\\.]+-macos-x64\\.pkg)"',
           'url': 'https://mmonit.com/monit/'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): dist/binary/5.34.3/monit-5.34.3-macos-x64.pkg
{'Output': {'match': 'dist/binary/5.34.3/monit-5.34.3-macos-x64.pkg'}}
URLDownloader
{'Input': {'url': 'https://mmonit.com/monit/dist/binary/5.34.3/monit-5.34.3-macos-x64.pkg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 10 Dec 2024 17:16:08 GMT
URLDownloader: Storing new ETag header: "1a62e9d-3814dc-628eda3145710"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.jleggat.pkg.Monit/downloads/monit-5.34.3-macos-x64.pkg
{'Output': {'download_changed': True,
            'etag': '"1a62e9d-3814dc-628eda3145710"',
            'last_modified': 'Tue, 10 Dec 2024 17:16:08 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.jleggat.pkg.Monit/downloads/monit-5.34.3-macos-x64.pkg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.jleggat.pkg.Monit/downloads/monit-5.34.3-macos-x64.pkg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Tildeslash '
                                        '(Z7D8RDKK69)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/com.github.jleggat.pkg.Monit/downloads/monit-5.34.3-macos-x64.pkg'}}
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "monit-5.34.3-macos-x64.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2024-12-10 16:37:40 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Tildeslash (Z7D8RDKK69)
CodeSignatureVerifier:        Expires: 2025-11-15 16:20:43 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            01 80 D1 CA 2A 63 73 CF 73 F9 3E 51 E2 87 A0 CB 63 04 CA 62 36 16
CodeSignatureVerifier:            E2 25 58 1E 2C 8C 45 A4 B9 0A
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
PkgCopier
{'Input': {'source_pkg': '~/Library/AutoPkg/Cache/com.github.jleggat.pkg.Monit/downloads/monit-5.34.3-macos-x64.pkg'}}
PkgCopier: Copied ~/Library/AutoPkg/Cache/com.github.jleggat.pkg.Monit/downloads/monit-5.34.3-macos-x64.pkg to ~/Library/AutoPkg/Cache/com.github.jleggat.pkg.Monit/monit-5.34.3-macos-x64.pkg
{'Output': {'pkg_copier_summary_result': {'data': {'pkg_path': '~/Library/AutoPkg/Cache/com.github.jleggat.pkg.Monit/monit-5.34.3-macos-x64.pkg'},
                                          'summary_text': 'The following '
                                                          'packages were '
                                                          'copied:'},
            'pkg_path': '~/Library/AutoPkg/Cache/com.github.jleggat.pkg.Monit/monit-5.34.3-macos-x64.pkg'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.jleggat.pkg.Monit/receipts/Monit.pkg-receipt-20241226-195159.plist
Processing Monit.munki.recipe...
WARNING: Monit.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href="(dist/binary/[\\d\\.]+/monit-[\\d\\.]+-macos-x64\\.pkg)"',
           'url': 'https://mmonit.com/monit/'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): dist/binary/5.34.3/monit-5.34.3-macos-x64.pkg
{'Output': {'match': 'dist/binary/5.34.3/monit-5.34.3-macos-x64.pkg'}}
URLDownloader
{'Input': {'url': 'https://mmonit.com/monit/dist/binary/5.34.3/monit-5.34.3-macos-x64.pkg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 10 Dec 2024 17:16:08 GMT
URLDownloader: Storing new ETag header: "1a62e9d-3814dc-628eda3145710"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.jleggat.munki.Monit/downloads/monit-5.34.3-macos-x64.pkg
{'Output': {'download_changed': True,
            'etag': '"1a62e9d-3814dc-628eda3145710"',
            'last_modified': 'Tue, 10 Dec 2024 17:16:08 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.jleggat.munki.Monit/downloads/monit-5.34.3-macos-x64.pkg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.jleggat.munki.Monit/downloads/monit-5.34.3-macos-x64.pkg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Tildeslash '
                                        '(Z7D8RDKK69)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/com.github.jleggat.munki.Monit/downloads/monit-5.34.3-macos-x64.pkg'}}
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "monit-5.34.3-macos-x64.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2024-12-10 16:37:40 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Tildeslash (Z7D8RDKK69)
CodeSignatureVerifier:        Expires: 2025-11-15 16:20:43 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            01 80 D1 CA 2A 63 73 CF 73 F9 3E 51 E2 87 A0 CB 63 04 CA 62 36 16
CodeSignatureVerifier:            E2 25 58 1E 2C 8C 45 A4 B9 0A
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
PkgCopier
{'Input': {'source_pkg': '~/Library/AutoPkg/Cache/com.github.jleggat.munki.Monit/downloads/monit-5.34.3-macos-x64.pkg'}}
PkgCopier: Copied ~/Library/AutoPkg/Cache/com.github.jleggat.munki.Monit/downloads/monit-5.34.3-macos-x64.pkg to ~/Library/AutoPkg/Cache/com.github.jleggat.munki.Monit/monit-5.34.3-macos-x64.pkg
{'Output': {'pkg_copier_summary_result': {'data': {'pkg_path': '~/Library/AutoPkg/Cache/com.github.jleggat.munki.Monit/monit-5.34.3-macos-x64.pkg'},
                                          'summary_text': 'The following '
                                                          'packages were '
                                                          'copied:'},
            'pkg_path': '~/Library/AutoPkg/Cache/com.github.jleggat.munki.Monit/monit-5.34.3-macos-x64.pkg'}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '~/Library/AutoPkg/Cache/com.github.jleggat.munki.Monit/downloads/monit-5.34.3-macos-x64.pkg',
           'pkginfo': {'catalogs': ['testing'],
                       'category': 'System Utilities',
                       'description': 'Monit is an open source utility for '
                                      'managing and monitoring, processes, '
                                      'programs, files, directories and '
                                      'filesystems on a UNIX system. Monit '
                                      'conducts automatic maintenance and '
                                      'repair and can execute meaningful '
                                      'causal actions in error situations.',
                       'developer': 'Tildeslash Ltd',
                       'display_name': 'Monit - Unix Systems Management',
                       'name': 'Monit',
                       'preuninstall_script': '#!/bin/sh\n'
                                              '## stop Monit\n'
                                              '/bin/launchctl unload -w '
                                              '/Library/LaunchDaemons/com.mmonit.monit.plist\n'
                                              'exit 0',
                       'unattended_install': True,
                       'unattended_uninstall': True,
                       'uninstall_method': 'removepackages',
                       'uninstallable': True},
           'repo_subdirectory': 'support/Monit'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/support/Monit/Monit-5.34.3.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/support/Monit/monit-5.34.3-macos-x64-5.34.3.pkg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'Monit',
                                                       'pkg_repo_path': 'support/Monit/monit-5.34.3-macos-x64-5.34.3.pkg',
                                                       'pkginfo_path': 'support/Monit/Monit-5.34.3.plist',
                                                       'version': '5.34.3'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'testuser',
                                         'creation_date': datetime.datetime(2024, 12, 27, 3, 52, 2),
                                         'munki_version': '6.6.3.4704',
                                         'os_version': '15.2'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'category': 'System Utilities',
                           'description': 'Monit is an open source utility for '
                                          'managing and monitoring, processes, '
                                          'programs, files, directories and '
                                          'filesystems on a UNIX system. Monit '
                                          'conducts automatic maintenance and '
                                          'repair and can execute meaningful '
                                          'causal actions in error situations.',
                           'developer': 'Tildeslash Ltd',
                           'display_name': 'Monit - Unix Systems Management',
                           'installed_size': 8712,
                           'installer_item_hash': '1177fabb57e42d5c50d8da3e8c767551a8f1133fb1055c30929fdf6c2e1d776e',
                           'installer_item_location': 'support/Monit/monit-5.34.3-macos-x64-5.34.3.pkg',
                           'installer_item_size': 3589,
                           'minimum_os_version': '10.5.0',
                           'name': 'Monit',
                           'preuninstall_script': '#!/bin/sh\n'
                                                  '## stop Monit\n'
                                                  '/bin/launchctl unload -w '
                                                  '/Library/LaunchDaemons/com.mmonit.monit.plist\n'
                                                  'exit 0',
                           'receipts': [{'installed_size': 8712,
                                         'packageid': 'com.tildeslash.monit',
                                         'version': '5.34.3'}],
                           'unattended_install': True,
                           'unattended_uninstall': True,
                           'uninstall_method': 'removepackages',
                           'uninstallable': True,
                           'version': '5.34.3'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/support/Monit/monit-5.34.3-macos-x64-5.34.3.pkg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/support/Monit/Monit-5.34.3.plist'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.jleggat.munki.Monit/receipts/Monit.munki-receipt-20241226-195202.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.jleggat.download.Monit/downloads/monit-5.34.3-macos-x64.pkg
    ~/Library/AutoPkg/Cache/com.github.jleggat.pkg.Monit/downloads/monit-5.34.3-macos-x64.pkg
    ~/Library/AutoPkg/Cache/com.github.jleggat.munki.Monit/downloads/monit-5.34.3-macos-x64.pkg

The following packages were copied:
    Pkg Path
    --------
    ~/Library/AutoPkg/Cache/com.github.jleggat.pkg.Monit/monit-5.34.3-macos-x64.pkg
    ~/Library/AutoPkg/Cache/com.github.jleggat.munki.Monit/monit-5.34.3-macos-x64.pkg

The following new items were imported into Munki:
    Name   Version  Catalogs  Pkginfo Path                      Pkg Repo Path                                    Icon Repo Path
    ----   -------  --------  ------------                      -------------                                    --------------
    Monit  5.34.3   testing   support/Monit/Monit-5.34.3.plist  support/Monit/monit-5.34.3-macos-x64-5.34.3.pkg
```

