### PR TITLE
Deprecate BatChmod recipes

### DIFF
--- a/BatChmod/BatChmod.download.recipe
+++ b/BatChmod/BatChmod.download.recipe
@@ -14,9 +14,18 @@
         <string>https://www.macchampion.com/arbysoft/batchmodappcast.xml</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.3</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>BatChmod is no longer available for download. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>SparkleUpdateInfoProvider</string>


### PR DESCRIPTION
This PR deprecates the BatChmod recipes, because the software is no longer available for download.
