### PR TITLE
Fix and simplify `ack` recipes

### DIFF
--- a/ack/ack.download.recipe
+++ b/ack/ack.download.recipe
@@ -10,33 +10,31 @@
     <dict>
         <key>NAME</key>
         <string>ack</string>
-        <key>DOWNLOAD_URL</key>
-        <string>https://beyondgrep.com</string>
-        <key>DOWNLOAD_PATTERN</key>
-       	<string>&lt;a href="(ack-.*-single-file)"</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.0</string>
     <key>Process</key>
     <array>
-        	<dict>
-        	    <key>Processor</key>
-        	    <string>URLTextSearcher</string>
-        	    <key>Arguments</key>
-        	    <dict>
-        	        <key>url</key>
-        	        <string>%DOWNLOAD_URL%/install</string>
-        	        <key>re_pattern</key>
-        	        <string>%DOWNLOAD_PATTERN%</string>
-        	    </dict>
-        	</dict>
+        <dict>
+            <key>Processor</key>
+            <string>URLTextSearcher</string>
+            <key>Arguments</key>
+            <dict>
+                <key>url</key>
+                <string>https://beyondgrep.com/install/</string>
+                <key>re_pattern</key>
+                <string>href="ack-v([\d\.]+)"&gt;single-file</string>
+                <key>result_output_var_name</key>
+                <string>version</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>%DOWNLOAD_URL%/%match%</string>
+                <string>https://beyondgrep.com/ack-v%version%</string>
                 <key>filename</key>
                 <string>%NAME%.pl</string>
             </dict>


### PR DESCRIPTION
This PR updates the download page and file pattern for downloading the `ack` tool. It also simplifies the recipe by moving unneeded input variables into the URLTextSearcher arguments, so they can be updated centrally in this repo rather than forcing each admin who creates an override to keep them updated in their override.

Verbose recipe run output:

```
% autopkg run -vvq 'ack/ack.download.recipe'
Processing ack/ack.download.recipe...
WARNING: ack/ack.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href="ack-v([\\d\\.]+)">single-file',
           'result_output_var_name': 'version',
           'url': 'https://beyondgrep.com/install/'}}
URLTextSearcher: Found matching text (version): 3.8.0
{'Output': {'version': '3.8.0'}}
URLDownloader
{'Input': {'filename': 'ack.pl', 'url': 'https://beyondgrep.com/ack-v3.8.0'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Sat, 21 Dec 2024 04:40:49 GMT
URLDownloader: Storing new ETag header: "676646d1-290d7"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.jleggat.ack.download/downloads/ack.pl
{'Output': {'download_changed': True,
            'etag': '"676646d1-290d7"',
            'last_modified': 'Sat, 21 Dec 2024 04:40:49 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.jleggat.ack.download/downloads/ack.pl',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.jleggat.ack.download/downloads/ack.pl'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.jleggat.ack.download/receipts/ack.download-receipt-20241226-193303.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.jleggat.ack.download/downloads/ack.pl
```