### PR TITLE
Deprecate LightPaper recipes

### DIFF
--- a/LightPaper/LightPaper.download.recipe
+++ b/LightPaper/LightPaper.download.recipe
@@ -16,9 +16,18 @@
 		<string>http://lightpaper.42squares.in/</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.4.2</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>LightPaper is no longer available for download. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
This PR deprecates the LightPaper recipes, since the website that hosted the software is no longer online.