### PR TITLE
Deprecate MenuMeters recipes

### DIFF
--- a/RagingMenace/MenuMeters.download.recipe
+++ b/RagingMenace/MenuMeters.download.recipe
@@ -14,9 +14,18 @@
         <string>https://www.ragingmenace.com/software/download/MenuMeters.dmg</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>MenuMeters by Raging Menace is not compatible with recent macOS versions (details: https://ragingmenace.com/software/menumeters/index.html#requirement). There is a fork of MenuMeters by yujitach that runs on newer macOS versions, and recipes for the yujitach version are available in the kevinmcox-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>


### PR DESCRIPTION
This PR deprecates the MenuMeters download recipe, since that software is no longer compatible with modern macOS versions.

There is a fork of MenuMeters by yujitach that runs on newer macOS versions, and recipes for the yujitach version are available in the kevinmcox-recipes repo.
