### PR TITLE
Change parent of AppCleaner install/munki recipes, deprecate download recipe

### DIFF
--- a/AppCleaner/AppCleaner.download.recipe
+++ b/AppCleaner/AppCleaner.download.recipe
@@ -14,9 +14,18 @@
         <string>https://freemacsoft.net/appcleaner/Updates.xml</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.3</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the AppCleaner recipes in the d33t5-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>SparkleUpdateInfoProvider</string>

--- a/AppCleaner/AppCleaner.install.recipe
+++ b/AppCleaner/AppCleaner.install.recipe
@@ -4,19 +4,19 @@
 <dict>
     <key>Description</key>
     <string>Downloads the current release of AppCleaner and installs it.</string>
-	<key>Identifier</key>
-	<string>com.github.jleggat.AppCleaner.install</string>
+    <key>Identifier</key>
+    <string>com.github.jleggat.AppCleaner.install</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>
         <string>AppCleaner</string>
-		<key>APP_DESTINATION</key>
-		<string>/Applications/Utilities</string>
+        <key>APP_DESTINATION</key>
+        <string>/Applications/Utilities</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.4.0</string>
     <key>ParentRecipe</key>
-    <string>com.github.jleggat.AppCleaner.download</string>
+    <string>com.github.d33t5.download.AppCleaner</string>
     <key>Process</key>
     <array>
         <dict>

--- a/AppCleaner/AppCleaner.munki.recipe
+++ b/AppCleaner/AppCleaner.munki.recipe
@@ -4,16 +4,16 @@
 <dict>
     <key>Description</key>
     <string>Downloads the current release of AppCleaner and imports it into munki.</string>
-	<key>Identifier</key>
-	<string>com.github.jleggat.AppCleaner.munki</string>
+    <key>Identifier</key>
+    <string>com.github.jleggat.AppCleaner.munki</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>
         <string>AppCleaner</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>utilities</string>
-		<key>APP_DESTINATION</key>
-		<string>/Applications/Utilities</string>
+        <key>APP_DESTINATION</key>
+        <string>/Applications/Utilities</string>
         <key>pkginfo</key>
         <dict>
             <key>catalogs</key>
@@ -28,31 +28,18 @@
             <string>%NAME%</string>
             <key>unattended_install</key>
             <true/>
-			<key>category</key>
-			<string>OS Utilities</string>
-			<key>developer</key>
-			<string>FreeMacSoft</string>
+            <key>category</key>
+            <string>OS Utilities</string>
+            <key>developer</key>
+            <string>FreeMacSoft</string>
         </dict>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.3</string>
     <key>ParentRecipe</key>
-    <string>com.github.jleggat.AppCleaner.download</string>
+    <string>com.github.d33t5.download.AppCleaner</string>
     <key>Process</key>
     <array>
-        <dict>
-            <key>Processor</key>
-            <string>Unarchiver</string>
-            <key>Arguments</key>
-            <dict>
-                <key>archive_path</key>
-                <string>%pathname%</string>
-                <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
-                <key>purge_destination</key>
-                <true/>
-            </dict>
-        </dict>
         <dict>
             <key>Processor</key>
             <string>DmgCreator</string>
@@ -71,11 +58,11 @@
                 <string>%dmg_path%</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
-				<key>additional_makepkginfo_options</key>
-				<array>
-					<string>--destinationpath</string>
-					<string>%APP_DESTINATION%</string>
-				</array>
+                <key>additional_makepkginfo_options</key>
+                <array>
+                    <string>--destinationpath</string>
+                    <string>%APP_DESTINATION%</string>
+                </array>
             </dict>
             <key>Processor</key>
             <string>MunkiImporter</string>


### PR DESCRIPTION
This PR changes the parent recipe of AppCleaner.install and AppCleaner.munki to the download recipe offered by d33t5-recipes, and deprecates the download recipe in this repo.

Verbose munki recipe run output:

```
% autopkg run -vvq AppCleaner.munki.recipe
Processing AppCleaner.munki.recipe...
WARNING: AppCleaner.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://freemacsoft.net/appcleaner/updates.xml'}}
SparkleUpdateInfoProvider: Items in feed: 3
SparkleUpdateInfoProvider: Items in default channel: 3
SparkleUpdateInfoProvider: Version retrieved from appcast: 4332
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 3.6.8
SparkleUpdateInfoProvider: Found URL https://rawcdn.githack.com/freemacsoft/appcleaner/8c3b52858a454d14fba343cf565ff710eaff4bcd/AppCleaner_3.6.8.zip
{'Output': {'url': 'https://rawcdn.githack.com/freemacsoft/appcleaner/8c3b52858a454d14fba343cf565ff710eaff4bcd/AppCleaner_3.6.8.zip',
            'version': '3.6.8'}}
URLDownloader
{'Input': {'filename': 'AppCleaner-3.6.8.zip',
           'url': 'https://rawcdn.githack.com/freemacsoft/appcleaner/8c3b52858a454d14fba343cf565ff710eaff4bcd/AppCleaner_3.6.8.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new ETag header: W/"4446bf5a8582d0ed7c8c8084f96787d66dc314e4686acb2d27b33e0e72c03b66"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.jleggat.AppCleaner.munki/downloads/AppCleaner-3.6.8.zip
{'Output': {'download_changed': True,
            'etag': 'W/"4446bf5a8582d0ed7c8c8084f96787d66dc314e4686acb2d27b33e0e72c03b66"',
            'pathname': '~/Library/AutoPkg/Cache/com.github.jleggat.AppCleaner.munki/downloads/AppCleaner-3.6.8.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.jleggat.AppCleaner.munki/downloads/AppCleaner-3.6.8.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.jleggat.AppCleaner.munki/downloads/AppCleaner-3.6.8.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.jleggat.AppCleaner.munki/AppCleaner',
           'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename AppCleaner-3.6.8.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.jleggat.AppCleaner.munki/downloads/AppCleaner-3.6.8.zip to ~/Library/AutoPkg/Cache/com.github.jleggat.AppCleaner.munki/AppCleaner
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.jleggat.AppCleaner.munki/AppCleaner/AppCleaner.app',
           'requirement': 'anchor apple generic and identifier '
                          '"net.freemacsoft.AppCleaner" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = X85ZX835W9)'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.jleggat.AppCleaner.munki/AppCleaner/AppCleaner.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.jleggat.AppCleaner.munki/AppCleaner/AppCleaner.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.jleggat.AppCleaner.munki/AppCleaner/AppCleaner.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
DmgCreator
{'Input': {'dmg_path': '~/Library/AutoPkg/Cache/com.github.jleggat.AppCleaner.munki/AppCleaner.dmg',
           'dmg_root': '~/Library/AutoPkg/Cache/com.github.jleggat.AppCleaner.munki/AppCleaner'}}
DmgCreator: Created dmg from ~/Library/AutoPkg/Cache/com.github.jleggat.AppCleaner.munki/AppCleaner at ~/Library/AutoPkg/Cache/com.github.jleggat.AppCleaner.munki/AppCleaner.dmg
{'Output': {}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'additional_makepkginfo_options': ['--destinationpath',
                                              '/Applications/Utilities'],
           'pkg_path': '~/Library/AutoPkg/Cache/com.github.jleggat.AppCleaner.munki/AppCleaner.dmg',
           'pkginfo': {'catalogs': ['testing'],
                       'category': 'OS Utilities',
                       'description': 'AppCleaner is a small application which '
                                      'allows you to thoroughly uninstall '
                                      'unwanted apps.',
                       'developer': 'FreeMacSoft',
                       'display_name': 'AppCleaner Uninstaller Utility',
                       'name': 'AppCleaner',
                       'unattended_install': True},
           'repo_subdirectory': 'utilities'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/utilities/AppCleaner-3.6.8.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/utilities/AppCleaner-3.6.8.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'AppCleaner',
                                                       'pkg_repo_path': 'utilities/AppCleaner-3.6.8.dmg',
                                                       'pkginfo_path': 'utilities/AppCleaner-3.6.8.plist',
                                                       'version': '3.6.8'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'testuser',
                                         'creation_date': datetime.datetime(2025, 1, 2, 3, 37, 7),
                                         'munki_version': '6.6.3.4704',
                                         'os_version': '15.2'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'category': 'OS Utilities',
                           'description': 'AppCleaner is a small application '
                                          'which allows you to thoroughly '
                                          'uninstall unwanted apps.',
                           'developer': 'FreeMacSoft',
                           'display_name': 'AppCleaner Uninstaller Utility',
                           'installer_item_hash': '90ff99dd1a59ca36d4f03308d62a51c161a1f4d59d14e032ea74778bd2aebe99',
                           'installer_item_location': 'utilities/AppCleaner-3.6.8.dmg',
                           'installer_item_size': 3968,
                           'installer_type': 'copy_from_dmg',
                           'installs': [{'CFBundleIdentifier': 'net.freemacsoft.AppCleaner',
                                         'CFBundleName': 'AppCleaner',
                                         'CFBundleShortVersionString': '3.6.8',
                                         'CFBundleVersion': '4332',
                                         'minosversion': '10.14',
                                         'path': '/Applications/Utilities/AppCleaner.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'items_to_copy': [{'destination_path': '/Applications/Utilities',
                                              'source_item': 'AppCleaner.app'}],
                           'minimum_os_version': '10.14',
                           'name': 'AppCleaner',
                           'unattended_install': True,
                           'uninstall_method': 'remove_copied_items',
                           'uninstallable': True,
                           'version': '3.6.8'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/utilities/AppCleaner-3.6.8.dmg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/utilities/AppCleaner-3.6.8.plist'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.jleggat.AppCleaner.munki/receipts/AppCleaner.munki-receipt-20250101-193707.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.jleggat.AppCleaner.munki/downloads/AppCleaner-3.6.8.zip

The following new items were imported into Munki:
    Name        Version  Catalogs  Pkginfo Path                      Pkg Repo Path                   Icon Repo Path
    ----        -------  --------  ------------                      -------------                   --------------
    AppCleaner  3.6.8    testing   utilities/AppCleaner-3.6.8.plist  utilities/AppCleaner-3.6.8.dmg
```


