### PR TITLE
Update all available URLs from HTTP to HTTPS

### DIFF
--- a/ne/ne.download.recipe
+++ b/ne/ne.download.recipe
@@ -11,7 +11,7 @@
 		<key>NAME</key>
 		<string>ne</string>
         	<key>DOWNLOAD_URL</key>
-        	<string>http://ne.di.unimi.it</string>
+        	<string>https://ne.di.unimi.it</string>
         	<key>SEARCH_PATTERN</key>
 		<string>(?P&lt;url&gt;[^"]+-(?P&lt;version&gt;[0-9\.]+)\.dmg)</string>
 	</dict>

--- a/pngout/pngout.download.recipe
+++ b/pngout/pngout.download.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>pngout</string>
         <key>DOWNLOAD_URL</key>
-        <string>http://www.jonof.id.au/kenutils</string>
+        <string>https://www.jonof.id.au/kenutils</string>
         <key>DOWNLOAD_PATTERN</key>
        	<string>([^"]+pngout-(?P&lt;version&gt;[0-9]+)-darwin\.tar\.gz)</string>
     </dict>

--- a/sqlitebrowser/sqlitebrowser.download.recipe
+++ b/sqlitebrowser/sqlitebrowser.download.recipe
@@ -9,7 +9,7 @@
         <key>NAME</key>
         <string>sqlitebrowser</string>
         <key>DOWNLOAD_URL</key>
-        <string>http://sqlitebrowser.org</string>
+        <string>https://sqlitebrowser.org</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.0</string>


### PR DESCRIPTION
It's important to use HTTPS for downloading software whenever possible in order to avoid the possibility of person-in-the-middle attacks (like the one that affected the Sparkle update framework [back in 2016](https://vulnsec.com/2016/osx-apps-vulnerabilities/)).

For this pull request, I detected and changed to HTTPS URLs automatically using my [HTTPS Spotter](https://www.elliotjordan.com/posts/autopkg-https/) script, and then tested all changed recipes manually to ensure exit codes of recipe run remains the same before/after the change.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._