### PR TITLE
Add code signature verification for AppCleaner

### DIFF
--- a/AppCleaner/AppCleaner.download.recipe
+++ b/AppCleaner/AppCleaner.download.recipe
@@ -34,6 +34,30 @@
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
         </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>archive_path</key>
+                <string>%pathname%</string>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+            <key>Processor</key>
+            <string>Unarchiver</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/AppCleaner.app</string>
+                <key>requirement</key>
+                <string>anchor apple generic and identifier "net.freemacsoft.AppCleaner" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = X85ZX835W9)</string>
+            </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+        </dict>
     </array>
 </dict>
 </plist>

--- a/AppCleaner/AppCleaner.munki.recipe
+++ b/AppCleaner/AppCleaner.munki.recipe
@@ -42,19 +42,6 @@
     <array>
         <dict>
             <key>Processor</key>
-            <string>Unarchiver</string>
-            <key>Arguments</key>
-            <dict>
-                <key>archive_path</key>
-                <string>%pathname%</string>
-                <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
-                <key>purge_destination</key>
-                <true/>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
             <string>DmgCreator</string>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
CodeSignatureVerifier section of verbose recipe run:

```
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.jleggat.AppCleaner.download/AppCleaner/AppCleaner.app',
           'requirement': 'anchor apple generic and identifier '
                          '"net.freemacsoft.AppCleaner" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = X85ZX835W9)'}}
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.jleggat.AppCleaner.download/AppCleaner/AppCleaner.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.jleggat.AppCleaner.download/AppCleaner/AppCleaner.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.jleggat.AppCleaner.download/AppCleaner/AppCleaner.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
```