### PR TITLE
Update all available URLs from HTTP to HTTPS

### DIFF
--- a/BonjourBrowser/BonjourBrowser.download.recipe
+++ b/BonjourBrowser/BonjourBrowser.download.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>BonjourBrowser</string>
         <key>DOWNLOAD_URL</key>
-        <string>http://www.tildesoft.com/files/BonjourBrowser.dmg</string>
+        <string>https://www.tildesoft.com/files/BonjourBrowser.dmg</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.0</string>

--- a/QLMarkdown/QLMarkdown.download.recipe
+++ b/QLMarkdown/QLMarkdown.download.recipe
@@ -13,7 +13,7 @@
 		<key>SEARCH_PATTERN</key>
 		<string>href="(?P&lt;url&gt;[^"]+)" id="markdown-quicklook-plugin"</string>
 		<key>SEARCH_URL</key>
-		<string>http://inkmarkapp.com/markdown-quick-look-plugin-mac-os-x/</string>
+		<string>https://inkmarkapp.com/markdown-quick-look-plugin-mac-os-x/</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.4.2</string>


### PR DESCRIPTION
It's important to use HTTPS for downloading software whenever possible in order to avoid the possibility of person-in-the-middle attacks (like the one that affected the Sparkle update framework [in January 2016](https://vulnsec.com/2016/osx-apps-vulnerabilities/)).

For this pull request, I detected and changed to HTTPS URLs automatically using my [HTTPS Spotter](https://www.elliotjordan.com/posts/autopkg-https/) script, and then tested all changed recipes manually to ensure exit codes of recipe run remains the same before/after the change.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.3.0._