### PR TITLE
fix(wireshark): Change regex download pattern for universal installer

### DIFF
--- a/Wireshark/Wireshark.download.recipe
+++ b/Wireshark/Wireshark.download.recipe
@@ -21,7 +21,7 @@
                 <key>url</key>
                 <string>https://www.wireshark.org/download.html</string>
                 <key>re_pattern</key>
-                <string>href="https:\/\/[^"]*(?P&lt;match&gt;osx/Wireshark[^"]*Intel[^"]*64\.dmg)"</string>
+                <string>href="https:\/\/[^"]*(?P&lt;match&gt;osx/Wireshark[^"]*\.dmg)"</string>
                 <key>re_flags</key>
                 <array>
                     <string>IGNORECASE</string>


### PR DESCRIPTION
change the regex to download the new stable universal installer.# Pull Request

## Summary

This pull request updates the AutoPkg configuration and related package definition files.

## Changes

- Updated `Wireshark/Wireshark.download.recipe`.


## Testing

- [x] Verified patch applies cleanly.
- [x] Validated package/build workflow.
- [x] Confirmed no unintended changes.

## Checklist

- [x] Code reviewed
- [x] Documentation updated where applicable
- [x] No unrelated changes included
